### PR TITLE
[Ego-31] Skip Maven tests during deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,13 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # Build!
+      # Skip tests - those are done in the test step and require specific DB configurations
       - run:
           name: Package Uber-Jar
-          command: mvn package
+          command: |
+            mvn package \
+            -Dmaven.test.skip=true
+
 
       # install rsync, needed for Deploy Script
       - add_ssh_keys


### PR DESCRIPTION
Maven failed tests during package step of deploy. Requiring it to skip tests will prevent this in the future. Tests are done separately so are not required in the deploy step.

https://github.com/overture-stack/ego/issues/31