### PR TITLE
[EGO-19] Allow "token" header in CorsFilter

### DIFF
--- a/src/main/java/org/overture/ego/security/CorsFilter.java
+++ b/src/main/java/org/overture/ego/security/CorsFilter.java
@@ -38,7 +38,7 @@ public class CorsFilter implements Filter {
     response.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, PATCH, HEAD, OPTIONS");
     response.addHeader("Access-Control-Allow-Headers",
         "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, " +
-            "Access-Control-Request-Headers, id_token, AUTHORIZATION");
+            "Access-Control-Request-Headers, token, AUTHORIZATION");
     response.addHeader("Access-Control-Expose-Headers", "Access-Control-Allow-Origin, Access-Control-Allow-Credentials");
     response.addHeader("Access-Control-Allow-Credentials", "true");
     response.addIntHeader("Access-Control-Max-Age", 10);


### PR DESCRIPTION
Without this browsers reject API calls to ego. This specifies we accept the "token" header form cross domain requests.

https://github.com/overture-stack/ego/issues/19