### PR TITLE
Fix LazyInitializationException

### DIFF
--- a/src/main/java/org/overture/ego/model/entity/Application.java
+++ b/src/main/java/org/overture/ego/model/entity/Application.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 import javax.persistence.*;
 import java.util.HashSet;
@@ -62,10 +64,12 @@ public class Application {
   String status;
 
   @ManyToMany(mappedBy = "applications", cascade = CascadeType.ALL)
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JsonIgnore
   List<Group> groups;
 
   @ManyToMany(mappedBy = "applications", cascade = CascadeType.ALL)
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JsonIgnore
   List<User> users;
 

--- a/src/main/java/org/overture/ego/model/entity/Group.java
+++ b/src/main/java/org/overture/ego/model/entity/Group.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -51,11 +53,13 @@ public class Group {
   String status;
 
   @ManyToMany(targetEntity = Application.class, cascade = {CascadeType.ALL})
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "groupapplication", joinColumns = { @JoinColumn(name = "grpid") },
           inverseJoinColumns = { @JoinColumn(name = "appid") })
   @JsonIgnore List<Application> applications;
 
   @ManyToMany(mappedBy = "groups", cascade = CascadeType.ALL)
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JsonIgnore
   List<User> users;
 

--- a/src/main/java/org/overture/ego/model/entity/User.java
+++ b/src/main/java/org/overture/ego/model/entity/User.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.*;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -78,12 +80,13 @@ public class User {
   String preferredLanguage;
 
   @ManyToMany(targetEntity = Group.class, cascade = {CascadeType.ALL})
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "usergroup", joinColumns = { @JoinColumn(name = "userid") },
           inverseJoinColumns = { @JoinColumn(name = "grpid") })
   @JsonIgnore protected List<Group> groups;
 
-
   @ManyToMany(targetEntity = Application.class, cascade = {CascadeType.ALL})
+  @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "userapplication", joinColumns = { @JoinColumn(name = "userid") },
           inverseJoinColumns = { @JoinColumn(name = "appid") })
   @JsonIgnore protected List<Application> applications;


### PR DESCRIPTION
Make LazyCollection FALSE for all Entity Relations. These were throwing LazyInitialization exceptions when populating the responses to the GET services.