### PR TITLE
[Ego-19] Demo Config Flag to get Demo User on Login

### DIFF
--- a/src/main/java/org/overture/ego/model/enums/UserRole.java
+++ b/src/main/java/org/overture/ego/model/enums/UserRole.java
@@ -30,4 +30,5 @@ public enum UserRole {
   public String toString() {
     return value;
   }
+
 }

--- a/src/main/java/org/overture/ego/model/enums/UserRole.java
+++ b/src/main/java/org/overture/ego/model/enums/UserRole.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2017. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.overture.ego.model.enums;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserRole {
+  USER("USER"),
+  ADMIN("ADMIN");
+
+  @NonNull private final String value;
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/src/main/java/org/overture/ego/model/enums/UserStatus.java
+++ b/src/main/java/org/overture/ego/model/enums/UserStatus.java
@@ -32,4 +32,5 @@ public enum UserStatus {
   public String toString() {
     return value;
   }
+
 }

--- a/src/main/java/org/overture/ego/model/enums/UserStatus.java
+++ b/src/main/java/org/overture/ego/model/enums/UserStatus.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.overture.ego.model.enums;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserStatus {
+  APPROVED("Approved"),
+  DISABLED("Disabled"),
+  PENDING("Pending"),
+  REJECTED("Rejected"),;
+
+  @NonNull private final String value;
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/src/main/java/org/overture/ego/service/UserService.java
+++ b/src/main/java/org/overture/ego/service/UserService.java
@@ -35,7 +35,6 @@ import org.springframework.util.StringUtils;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
 

--- a/src/main/java/org/overture/ego/service/UserService.java
+++ b/src/main/java/org/overture/ego/service/UserService.java
@@ -20,6 +20,8 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.overture.ego.model.entity.User;
+import org.overture.ego.model.enums.UserRole;
+import org.overture.ego.model.enums.UserStatus;
 import org.overture.ego.repository.UserRepository;
 import org.overture.ego.repository.queryspecification.UserSpecification;
 import org.overture.ego.token.IDToken;
@@ -27,23 +29,33 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
 
 @Slf4j
 @Service
+@Transactional
 public class UserService {
 
   /*
     Constants
    */
-  private final static String DEFAULT_USER_ROLE = "USER";
-  private final static String DEFAULT_USER_STATUS = "Pending";
+  // DEFAULTS
+  private final static String DEFAULT_USER_ROLE = UserRole.USER.toString();
+  private final static String DEFAULT_USER_STATUS = UserStatus.PENDING.toString();
+
+  // DEMO USER
+  private final static String DEMO_USER_NAME = "Demo.User@example.com";
+  private final static String DEMO_USER_EMAIL = "Demo.User@example.com";
+  private final static String DEMO_FIRST_NAME = "Demo";
+  private final static String DEMO_LAST_NAME = "User";
 
   /*
     Dependencies
@@ -62,7 +74,6 @@ public class UserService {
   }
 
   public User createFromIDToken(IDToken idToken) {
-    // Create a new user
     val userInfo = new User();
     userInfo.setName(idToken.getEmail());
     userInfo.setEmail(idToken.getEmail());
@@ -73,6 +84,30 @@ public class UserService {
     userInfo.setLastLogin(null);
     userInfo.setRole(DEFAULT_USER_ROLE);
     return this.create(userInfo);
+  }
+
+  public User getOrCreateDemoUser() {
+    User output = getByName(DEMO_USER_NAME);
+
+    if (output != null) {
+      // Force the demo user to be ADMIN and APPROVED to allow demo access,
+      // even if these values have previously been modified for the demo user.
+      output.setStatus(UserStatus.APPROVED.toString());
+      output.setRole(UserRole.ADMIN.toString());
+    } else {
+      val userInfo = new User();
+      userInfo.setName(DEMO_USER_NAME);
+      userInfo.setEmail(DEMO_USER_EMAIL);
+      userInfo.setFirstName(DEMO_FIRST_NAME);
+      userInfo.setLastName(DEMO_LAST_NAME);
+      userInfo.setStatus(UserStatus.APPROVED.toString());
+      userInfo.setCreatedAt(formatter.format(new Date()));
+      userInfo.setLastLogin(null);
+      userInfo.setRole(UserRole.ADMIN.toString());
+      output = this.create(userInfo);
+    }
+
+    return output;
   }
 
   public void addUsersToGroups(@NonNull String userId, @NonNull List<String> groupIDs){

--- a/src/main/java/org/overture/ego/token/TokenService.java
+++ b/src/main/java/org/overture/ego/token/TokenService.java
@@ -32,16 +32,26 @@ import java.util.Map;
 @Service
 public class TokenService {
 
+  @Value("${demo:false}")
+  private boolean demo;
+
   @Value("${jwt.secret}")
   private String jwtSecret;
   @Autowired
   UserService userService;
 
   public String generateUserToken(IDToken idToken){
-    val userName = idToken.getEmail();
-    User user = userService.getByName(userName);
-    if (user == null) {
-      userService.createFromIDToken(idToken);
+    // If the demo flag is set, all tokens will be generated as the Demo User,
+    // rather than the user associated with their idToken
+    User user;
+    if (demo) {
+      user = userService.getOrCreateDemoUser();
+    } else {
+      val userName = idToken.getEmail();
+      user = userService.getByName(userName);
+      if (user == null) {
+        userService.createFromIDToken(idToken);
+      }
     }
     return generateUserToken(new TokenUserInfo(user));
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,3 +66,13 @@ logging:
     threshold: ALL
   loggers:
     "org.skife.jdbi.v2": TRACE
+
+---
+###############################################################################
+# Profile - "secure"
+###############################################################################
+spring:
+  profiles: demo
+
+# demo flag
+demo: true


### PR DESCRIPTION
Demo server will allow all user's to log in and no user data to be persisted.

This is a repeat of work done in #20 but updated to work with the JPA refactor.

Enums are added back in, UserStatus now includes all 4 values permittable by the DB schema.

https://github.com/overture-stack/ego/issues/19