### PR TITLE
Fix StackOverflowError for Users with Groups/Apps

### DIFF
--- a/src/main/java/org/overture/ego/model/entity/Application.java
+++ b/src/main/java/org/overture/ego/model/entity/Application.java
@@ -30,6 +30,7 @@ import java.util.List;
 @Entity
 @Table(name = "egoapplication")
 @Data
+@ToString(exclude={"groups","users"})
 @JsonPropertyOrder({"id", "name", "clientId", "clientSecret", "redirectUri", "description", "status"})
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @EqualsAndHashCode(of={"id"})

--- a/src/main/java/org/overture/ego/model/entity/Group.java
+++ b/src/main/java/org/overture/ego/model/entity/Group.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@ToString(exclude={"users","applications"})
 @Table(name = "egogroup")
 @Entity
 @JsonPropertyOrder({"id", "name", "description", "status","applications"})

--- a/src/main/java/org/overture/ego/model/entity/User.java
+++ b/src/main/java/org/overture/ego/model/entity/User.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "egouser")
 @Data
+@ToString(exclude={"groups","applications"})
 @JsonPropertyOrder({"id", "name", "email", "role", "status", "groups",
     "applications", "firstName", "lastName", "createdAt", "lastLogin", "preferredLanguage"})
 @JsonInclude(JsonInclude.Include.ALWAYS)


### PR DESCRIPTION
StackOverflowExceptions due to infinite loop was occuring for toString calls on Entities that had a relation to another entity. This was due to the default Lombok toString method which would print the value of all members. Due to relations, this caused infinite loops.

The solution is to exclude relations from Lombok's toString. The @ToString annotation allows specific fields to be excluded, fixing the infinite ToString loop.