### PR TITLE
Refactor User Event and Receiver

### DIFF
--- a/src/main/java/org/overture/ego/reactor/events/UserEvents.java
+++ b/src/main/java/org/overture/ego/reactor/events/UserEvents.java
@@ -1,5 +1,25 @@
 package org.overture.ego.reactor.events;
 
-public enum UserEvents {
-  UPDATE
+import org.overture.ego.model.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@Service
+public class UserEvents {
+
+  // EVENT NAMES
+  public static String UPDATE = UserEvents.class.getName() + ".UPDATE";
+
+  @Autowired
+  private EventBus eventBus;
+
+  public void update(User user) {
+    eventBus.notify(
+      UserEvents.UPDATE.toString(),
+      Event.wrap(user)
+    );
+  }
+
 }

--- a/src/main/java/org/overture/ego/reactor/events/UserEvents.java
+++ b/src/main/java/org/overture/ego/reactor/events/UserEvents.java
@@ -17,7 +17,7 @@ public class UserEvents {
 
   public void update(User user) {
     eventBus.notify(
-      UserEvents.UPDATE.toString(),
+      UserEvents.UPDATE,
       Event.wrap(user)
     );
   }

--- a/src/main/java/org/overture/ego/reactor/receiver/UserReceiver.java
+++ b/src/main/java/org/overture/ego/reactor/receiver/UserReceiver.java
@@ -1,5 +1,6 @@
 package org.overture.ego.reactor.receiver;
 
+import lombok.extern.slf4j.Slf4j;
 import org.overture.ego.model.entity.User;
 import org.overture.ego.reactor.events.UserEvents;
 import org.overture.ego.service.UserService;
@@ -14,6 +15,7 @@ import javax.annotation.PostConstruct;
 
 
 @Component
+@Slf4j
 public class UserReceiver {
 
   @Autowired
@@ -28,13 +30,21 @@ public class UserReceiver {
 
     // UPDATE
     eventBus.on(
-      Selectors.R(UserEvents.UPDATE.toString()),
+      Selectors.R(UserEvents.UPDATE),
       update()
     );
   }
 
-  private Consumer<Event<User>> update() {
-    return (updateEvent) -> userService.update(updateEvent.getData());
+  private Consumer<Event<?>> update() {
+    return (updateEvent) -> {
+      log.debug("Update event received: " + updateEvent.getData());
+      try {
+        User data = (User) updateEvent.getData();
+        userService.update(data);
+      } catch (ClassCastException e) {
+        log.error("Update event received incompatible data type.", e);
+      }
+    };
   }
 
 }

--- a/src/main/java/org/overture/ego/service/UserService.java
+++ b/src/main/java/org/overture/ego/service/UserService.java
@@ -66,7 +66,7 @@ public class UserService {
   @Autowired
   private ApplicationService applicationService;
   @Autowired
-  SimpleDateFormat formatter;
+  private SimpleDateFormat formatter;
 
   public User create(@NonNull User userInfo) {
     return userRepository.save(userInfo);

--- a/src/main/java/org/overture/ego/token/TokenService.java
+++ b/src/main/java/org/overture/ego/token/TokenService.java
@@ -41,11 +41,11 @@ public class TokenService {
   @Value("${jwt.secret}")
   private String jwtSecret;
   @Autowired
-  UserService userService;
+  private UserService userService;
   @Autowired
-  UserEvents userEvents;
+  private UserEvents userEvents;
   @Autowired
-  SimpleDateFormat dateFormatter;
+  private SimpleDateFormat dateFormatter;
 
   public String generateUserToken(IDToken idToken){
     // If the demo flag is set, all tokens will be generated as the Demo User,

--- a/src/main/java/org/overture/ego/token/TokenService.java
+++ b/src/main/java/org/overture/ego/token/TokenService.java
@@ -26,8 +26,6 @@ import org.overture.ego.utils.Types;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import reactor.bus.Event;
-import reactor.bus.EventBus;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -45,10 +43,9 @@ public class TokenService {
   @Autowired
   UserService userService;
   @Autowired
-  SimpleDateFormat dateFormatter;
-
+  UserEvents userEvents;
   @Autowired
-  EventBus eventBus;
+  SimpleDateFormat dateFormatter;
 
   public String generateUserToken(IDToken idToken){
     // If the demo flag is set, all tokens will be generated as the Demo User,
@@ -65,12 +62,10 @@ public class TokenService {
     }
 
     // Update user.lastLogin in the DB
-    // Do this via eventBus (Non-blocking)
+    // Use events as these are async:
+    //    the DB call won't block returning the Token
     user.setLastLogin(dateFormatter.format(new Date()));
-    eventBus.notify(
-      UserEvents.UPDATE.toString(),
-      Event.wrap(user)
-    );
+    userEvents.update(user);
 
     return generateUserToken(new TokenUserInfo(user));
   }


### PR DESCRIPTION
Addresses two problems:
1. Event name wasn't unique, was reporting as "UPDATE". By adding the class name to the event identifier there won't be confusion between different update events.
2. The EventBus would break on dispatch of an event if the notify event had a different Object type than one of its subscribers. Some testing showed that this would prevent events with the matching data type from receiving the event - stopped dispatch completely. Careful coding would ensure all events had a data type to match the consumers, but this but the safer way to handle it is to make all Consumers of type Event<?> so that they will accept all Event payloads, and then to make the consumer explicitly cast the payload to the type they expect.

Now that the consumers are safe to receive all Events, we want to make it straightforward for users of our Events to pass the expected data type. To do this, we moved the eventBus.notify code into a method in the UserEvent class. Now the invoker of the event doesn't need to know about the eventBus or any reactor code - only needs to call UserEvents.update(user). This also ensures that the correct type of object is passed in the Event payload.