### PR TITLE
Enhancement: We now always throw a DontSetIdInCreateRequestException …

### DIFF
--- a/src/main/java/org/overture/ego/controller/AclEntityController.java
+++ b/src/main/java/org/overture/ego/controller/AclEntityController.java
@@ -8,7 +8,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.overture.ego.model.dto.PageDTO;
 import org.overture.ego.model.entity.AclEntity;
-import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
+import org.overture.ego.model.exceptions.PostWithIdentifierException;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
 import org.overture.ego.security.AdminScoped;
@@ -66,7 +66,7 @@ public class AclEntityController {
   @ApiResponses(
         value = {
           @ApiResponse(code = 200, message = "New ACL Entity", response = AclEntity.class),
-          @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response=AclEntity.class)
+          @ApiResponse(code = 400, message = PostWithIdentifierException.reason, response=AclEntity.class)
       }
   )
   public @ResponseBody
@@ -74,7 +74,7 @@ public class AclEntityController {
     @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
     @RequestBody(required = true) AclEntity aclEntity ) {
     if (aclEntity.getId() != null) {
-      throw new DontSetIdInCreateRequestException();
+      throw new PostWithIdentifierException();
     }
     return aclEntityService.create(aclEntity);
   }

--- a/src/main/java/org/overture/ego/controller/AclEntityController.java
+++ b/src/main/java/org/overture/ego/controller/AclEntityController.java
@@ -20,9 +20,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/org/overture/ego/controller/AclEntityController.java
+++ b/src/main/java/org/overture/ego/controller/AclEntityController.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.overture.ego.model.dto.PageDTO;
 import org.overture.ego.model.entity.AclEntity;
+import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
 import org.overture.ego.security.AdminScoped;
@@ -20,6 +21,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -64,14 +67,18 @@ public class AclEntityController {
   @AdminScoped
   @RequestMapping(method = RequestMethod.POST, value = "")
   @ApiResponses(
-      value = {
-          @ApiResponse(code = 200, message = "New ACL Entity", response = AclEntity.class)
+        value = {
+          @ApiResponse(code = 200, message = "New ACL Entity", response = AclEntity.class),
+          @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response=AclEntity.class)
       }
   )
   public @ResponseBody
   AclEntity create(
-      @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
-      @RequestBody(required = true) AclEntity aclEntity) {
+    @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
+    @RequestBody(required = true) AclEntity aclEntity ) {
+    if (aclEntity.getId() != null) {
+      throw new DontSetIdInCreateRequestException();
+    }
     return aclEntityService.create(aclEntity);
   }
 

--- a/src/main/java/org/overture/ego/controller/ApplicationController.java
+++ b/src/main/java/org/overture/ego/controller/ApplicationController.java
@@ -26,7 +26,7 @@ import org.overture.ego.model.dto.PageDTO;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
-import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
+import org.overture.ego.model.exceptions.PostWithIdentifierException;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
 import org.overture.ego.security.AdminScoped;
@@ -100,7 +100,7 @@ public class ApplicationController {
   @ApiResponses(
       value = {
           @ApiResponse(code = 200, message = "New Application", response = Application.class),
-          @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = Application.class)
+          @ApiResponse(code = 400, message = PostWithIdentifierException.reason, response = Application.class)
       }
   )
   public @ResponseBody
@@ -108,7 +108,7 @@ public class ApplicationController {
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @RequestBody(required = true) Application applicationInfo) {
     if (applicationInfo.getId() != null) {
-      throw new DontSetIdInCreateRequestException();
+      throw new PostWithIdentifierException();
     }
 
     return applicationService.create(applicationInfo);

--- a/src/main/java/org/overture/ego/controller/ApplicationController.java
+++ b/src/main/java/org/overture/ego/controller/ApplicationController.java
@@ -23,9 +23,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.overture.ego.model.dto.PageDTO;
+import org.overture.ego.model.entity.AclEntity;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
+import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
 import org.overture.ego.security.AdminScoped;
@@ -98,13 +100,18 @@ public class ApplicationController {
   @RequestMapping(method = RequestMethod.POST, value = "")
   @ApiResponses(
       value = {
-          @ApiResponse(code = 200, message = "New Application", response = Application.class)
+          @ApiResponse(code = 200, message = "New Application", response = Application.class),
+          @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = Application.class)
       }
   )
   public @ResponseBody
   Application create(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @RequestBody(required = true) Application applicationInfo) {
+    if (applicationInfo.getId() != null) {
+      throw new DontSetIdInCreateRequestException();
+    }
+
     return applicationService.create(applicationInfo);
   }
 

--- a/src/main/java/org/overture/ego/controller/ApplicationController.java
+++ b/src/main/java/org/overture/ego/controller/ApplicationController.java
@@ -23,7 +23,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.overture.ego.model.dto.PageDTO;
-import org.overture.ego.model.entity.AclEntity;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;

--- a/src/main/java/org/overture/ego/controller/GroupController.java
+++ b/src/main/java/org/overture/ego/controller/GroupController.java
@@ -27,6 +27,7 @@ import org.overture.ego.model.entity.AclGroupPermission;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
+import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
 import org.overture.ego.model.params.Permission;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
@@ -104,13 +105,17 @@ public class GroupController {
   @RequestMapping(method = RequestMethod.POST, value = "")
   @ApiResponses(
       value = {
-          @ApiResponse(code = 200, message = "New Group", response = Group.class)
+        @ApiResponse(code = 200, message = "New Group", response = Group.class),
+        @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = Group.class)
       }
   )
   public @ResponseBody
   Group createGroup(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @RequestBody(required = true) Group groupInfo) {
+    if (groupInfo.getId() != null) {
+      throw new DontSetIdInCreateRequestException();
+    }
     return groupService.create(groupInfo);
   }
 
@@ -187,7 +192,7 @@ public class GroupController {
   @RequestMapping(method = RequestMethod.POST, value = "/{id}/permissions")
   @ApiResponses(
       value = {
-          @ApiResponse(code = 200, message = "Add group permissions", response = String.class)
+        @ApiResponse(code = 200, message = "Add group permissions", response = String.class)
       }
   )
   public @ResponseBody

--- a/src/main/java/org/overture/ego/controller/GroupController.java
+++ b/src/main/java/org/overture/ego/controller/GroupController.java
@@ -27,7 +27,7 @@ import org.overture.ego.model.entity.AclGroupPermission;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
-import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
+import org.overture.ego.model.exceptions.PostWithIdentifierException;
 import org.overture.ego.model.params.Permission;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
@@ -106,7 +106,7 @@ public class GroupController {
   @ApiResponses(
       value = {
         @ApiResponse(code = 200, message = "New Group", response = Group.class),
-        @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = Group.class)
+        @ApiResponse(code = 400, message = PostWithIdentifierException.reason, response = Group.class)
       }
   )
   public @ResponseBody
@@ -114,7 +114,7 @@ public class GroupController {
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @RequestBody(required = true) Group groupInfo) {
     if (groupInfo.getId() != null) {
-      throw new DontSetIdInCreateRequestException();
+      throw new PostWithIdentifierException();
     }
     return groupService.create(groupInfo);
   }

--- a/src/main/java/org/overture/ego/controller/UserController.java
+++ b/src/main/java/org/overture/ego/controller/UserController.java
@@ -24,7 +24,7 @@ import org.overture.ego.model.entity.AclUserPermission;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
-import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
+import org.overture.ego.model.exceptions.PostWithIdentifierException;
 import org.overture.ego.model.params.Permission;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
@@ -103,7 +103,7 @@ public class UserController {
   @ApiResponses(
           value = {
             @ApiResponse(code = 200, message = "Create new user", response = User.class),
-            @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = User.class)
+            @ApiResponse(code = 400, message = PostWithIdentifierException.reason, response = User.class)
           }
   )
   public @ResponseBody
@@ -111,7 +111,7 @@ public class UserController {
           @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
           @RequestBody(required = true) User userInfo) {
     if (userInfo.getId() != null) {
-      throw new DontSetIdInCreateRequestException();
+      throw new PostWithIdentifierException();
     }
     return userService.create(userInfo);
   }

--- a/src/main/java/org/overture/ego/controller/UserController.java
+++ b/src/main/java/org/overture/ego/controller/UserController.java
@@ -24,6 +24,7 @@ import org.overture.ego.model.entity.AclUserPermission;
 import org.overture.ego.model.entity.Application;
 import org.overture.ego.model.entity.Group;
 import org.overture.ego.model.entity.User;
+import org.overture.ego.model.exceptions.DontSetIdInCreateRequestException;
 import org.overture.ego.model.params.Permission;
 import org.overture.ego.model.search.Filters;
 import org.overture.ego.model.search.SearchFilter;
@@ -101,13 +102,17 @@ public class UserController {
   @RequestMapping(method = RequestMethod.POST, value = "")
   @ApiResponses(
           value = {
-                  @ApiResponse(code = 200, message = "Create new user", response = User.class)
+            @ApiResponse(code = 200, message = "Create new user", response = User.class),
+            @ApiResponse(code = 400, message = DontSetIdInCreateRequestException.reason, response = User.class)
           }
   )
   public @ResponseBody
   User create(
           @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
           @RequestBody(required = true) User userInfo) {
+    if (userInfo.getId() != null) {
+      throw new DontSetIdInCreateRequestException();
+    }
     return userService.create(userInfo);
   }
 

--- a/src/main/java/org/overture/ego/model/exceptions/DontSetIdInCreateRequestException.java
+++ b/src/main/java/org/overture/ego/model/exceptions/DontSetIdInCreateRequestException.java
@@ -1,0 +1,9 @@
+package org.overture.ego.model.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value= HttpStatus.BAD_REQUEST, reason=DontSetIdInCreateRequestException.reason)
+public class DontSetIdInCreateRequestException extends RuntimeException {
+  public static final String reason="Create requests must not include the 'id' field.";
+}

--- a/src/main/java/org/overture/ego/model/exceptions/PostWithIdentifierException.java
+++ b/src/main/java/org/overture/ego/model/exceptions/PostWithIdentifierException.java
@@ -3,7 +3,7 @@ package org.overture.ego.model.exceptions;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value= HttpStatus.BAD_REQUEST, reason=DontSetIdInCreateRequestException.reason)
-public class DontSetIdInCreateRequestException extends RuntimeException {
+@ResponseStatus(value= HttpStatus.BAD_REQUEST, reason= PostWithIdentifierException.reason)
+public class PostWithIdentifierException extends RuntimeException {
   public static final String reason="Create requests must not include the 'id' field.";
 }


### PR DESCRIPTION
…when an id that gets auto-generated is mistakenly provided in a POST request.