### PR TITLE
Feature/cascading hibernate

### DIFF
--- a/src/main/java/org/overture/ego/model/entity/Application.java
+++ b/src/main/java/org/overture/ego/model/entity/Application.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.*;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -77,13 +78,19 @@ public class Application {
   @Column(name = Fields.STATUS)
   String status;
 
-  @ManyToMany(mappedBy = "wholeApplications", cascade = CascadeType.ALL)
+  @ManyToMany()
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
+  @JoinTable(name = "groupapplication", joinColumns = { @JoinColumn(name = Fields.APPID_JOIN) },
+    inverseJoinColumns = { @JoinColumn(name = Fields.GROUPID_JOIN) })
   @JsonIgnore
   Set<Group> wholeGroups;
 
-  @ManyToMany(mappedBy = "wholeApplications", cascade = CascadeType.ALL)
+  @ManyToMany()
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
+  @JoinTable(name = "userapplication", joinColumns = {@JoinColumn(name = Fields.APPID_JOIN)},
+    inverseJoinColumns = {@JoinColumn(name = Fields.USERID_JOIN)})
   @JsonIgnore
   Set<User> wholeUsers;
 

--- a/src/main/java/org/overture/ego/model/entity/Group.java
+++ b/src/main/java/org/overture/ego/model/entity/Group.java
@@ -62,7 +62,8 @@ public class Group implements PolicyOwner {
   @Column(nullable = false, name = Fields.STATUS, updatable = false)
   String status;
 
-  @ManyToMany(targetEntity = Application.class, cascade = {CascadeType.ALL})
+  @ManyToMany(targetEntity = Application.class)
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "groupapplication", joinColumns = { @JoinColumn(name = Fields.GROUPID_JOIN) },
           inverseJoinColumns = { @JoinColumn(name = Fields.APPID_JOIN) })

--- a/src/main/java/org/overture/ego/model/entity/Group.java
+++ b/src/main/java/org/overture/ego/model/entity/Group.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.*;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -68,8 +69,11 @@ public class Group implements PolicyOwner {
   @JsonIgnore
   Set<Application> wholeApplications;
 
-  @ManyToMany(mappedBy = "wholeGroups", cascade = CascadeType.ALL)
+  @ManyToMany()
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
+  @JoinTable(name = "usergroup", joinColumns = {@JoinColumn(name = Fields.GROUPID_JOIN)},
+    inverseJoinColumns = {@JoinColumn(name = Fields.USERID_JOIN)})
   @JsonIgnore
   Set<User> wholeUsers;
 

--- a/src/main/java/org/overture/ego/model/entity/User.java
+++ b/src/main/java/org/overture/ego/model/entity/User.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.*;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
@@ -95,7 +96,8 @@ public class User implements PolicyOwner {
   @Column(name = Fields.PREFERREDLANGUAGE)
   String preferredLanguage;
 
-  @ManyToMany(targetEntity = Group.class, cascade = {CascadeType.ALL})
+  @ManyToMany(targetEntity = Group.class)
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "usergroup", joinColumns = {@JoinColumn(name = Fields.USERID_JOIN)},
       inverseJoinColumns = {@JoinColumn(name = Fields.GROUPID_JOIN)})

--- a/src/main/java/org/overture/ego/model/entity/User.java
+++ b/src/main/java/org/overture/ego/model/entity/User.java
@@ -104,7 +104,8 @@ public class User implements PolicyOwner {
   @JsonIgnore
   protected Set<Group> wholeGroups;
 
-  @ManyToMany(targetEntity = Application.class, cascade = {CascadeType.ALL})
+  @ManyToMany(targetEntity = Application.class)
+  @Cascade(org.hibernate.annotations.CascadeType.SAVE_UPDATE)
   @LazyCollection(LazyCollectionOption.FALSE)
   @JoinTable(name = "userapplication", joinColumns = {@JoinColumn(name = Fields.USERID_JOIN)},
       inverseJoinColumns = {@JoinColumn(name = Fields.APPID_JOIN)})

--- a/src/test/java/org/overture/ego/token/TokenServiceTest.java
+++ b/src/test/java/org/overture/ego/token/TokenServiceTest.java
@@ -63,7 +63,6 @@ public class TokenServiceTest {
     val group2 = groupService.getByName("testGroup");
     group2.addUser(user);
     groupService.update(group2);
-    val groupShit = groupService.getByName("testGroup");
 
     val app2 = applicationService.getByClientId("foo");
     app2.setWholeUsers(Sets.newHashSet(user));

--- a/src/test/java/org/overture/ego/token/TokenServiceTest.java
+++ b/src/test/java/org/overture/ego/token/TokenServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.overture.ego.token;
+
+import com.google.common.collect.Sets;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.overture.ego.service.ApplicationService;
+import org.overture.ego.service.GroupService;
+import org.overture.ego.service.UserService;
+import org.overture.ego.utils.EntityGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.util.Pair;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@SpringBootTest
+@RunWith(SpringRunner.class)
+@ActiveProfiles("test")
+@Ignore
+public class TokenServiceTest {
+  @Autowired
+  private ApplicationService applicationService;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private GroupService groupService;
+
+  @Autowired
+  private EntityGenerator entityGenerator;
+
+  @Autowired
+  private TokenService tokenService;
+
+  @Test
+  public void generateUserToken() {
+    val user = userService.create(entityGenerator.createOneUser(Pair.of("foo", "bar")));
+    val group = groupService.create(entityGenerator.createOneGroup("testGroup"));
+    val app = applicationService.create(entityGenerator.createOneApplication("foo"));
+
+    val group2 = groupService.getByName("testGroup");
+    group2.addUser(user);
+    groupService.update(group2);
+    val groupShit = groupService.getByName("testGroup");
+
+    val app2 = applicationService.getByClientId("foo");
+    app2.setWholeUsers(Sets.newHashSet(user));
+    applicationService.update(app2);
+
+
+    val token = tokenService.generateUserToken(userService.get(user.getId().toString()));
+  }
+
+}


### PR DESCRIPTION
Fixes the cascade type and move the cascade definition to use the hibernate annotations rather than the JPA ones. 

Added tests on group service to verify applications and groups will not get wiped out through a rogue cascade on delete by deleting a group. 

Added an ignored test for token services allowing quick stubbing and debugging of token generation.  

Related to this issue: #154