### PR TITLE
Add production dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,25 @@ jobs:
 
       - run: docker push overture/ego:$(git describe --always)-alpine
 
+  deploy-staging:
+    machine: true
+
+    steps:
+      - checkout
+
+      - run: mkdir ~/.kube && echo $KUBE_CONFIG | base64 --decode > ~/.kube/config
+
+      - run: wget https://storage.googleapis.com/kubernetes-helm/helm-v2.12.1-linux-amd64.tar.gz
+
+      - run: tar -xvf helm-v2.12.1-linux-amd64.tar.gz
+
+      - run: linux-amd64/helm init --client-only
+
+      - run: linux-amd64/helm repo add overture https://overture-stack.github.io/charts/
+
+      - run: echo $HELM_SECRETS | base64 --decode > values.secrets.yaml
+
+      - run: linux-amd64/helm upgrade ego-staging overture/ego -f values.secrets.yaml --set image.tag=$(git describe --always)-alpine
 
   deploy:
     docker:
@@ -93,7 +112,7 @@ jobs:
 
 workflows:
   version: 2
-  test-deploy:
+  test-build-deploy:
     jobs:
       - test
       - deploy:
@@ -104,3 +123,6 @@ workflows:
               only:
                 - develop
       - build-docker-image
+      - deploy-staging:
+          requires:
+            - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,19 @@ jobs:
             mvn test \
             -D spring.profiles.active=test
 
+  build-docker-image:
+    machine: true
+
+    steps:
+      - checkout
+
+      - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+      - run: docker build -f Dockerfile.prod . -t overture/ego:$(git describe --always)-alpine
+
+      - run: docker push overture/ego:$(git describe --always)-alpine
+
+
   deploy:
     docker:
       - image: circleci/openjdk:8-jdk
@@ -78,7 +91,6 @@ jobs:
           name: Deploy Script
           command: ./.circleci/deploy.sh
 
-
 workflows:
   version: 2
   test-deploy:
@@ -91,4 +103,4 @@ workflows:
             branches:
               only:
                 - develop
-                
+      - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,11 @@ workflows:
             branches:
               only:
                 - develop
-      - build-docker-image
+      - build-docker-image:
+          filters:
+            branches:
+              only:
+                - develop
       - deploy-staging:
           requires:
             - build-docker-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,7 @@ jobs:
 
       - run: linux-amd64/helm repo add overture https://overture-stack.github.io/charts/
 
-      - run: echo $HELM_SECRETS | base64 --decode > values.secrets.yaml
-
-      - run: linux-amd64/helm upgrade ego-staging overture/ego -f values.secrets.yaml --set image.tag=$(git describe --always)-alpine
+      - run: linux-amd64/helm upgrade ego-staging overture/ego --reuse-values --set image.tag=$(git describe --always)-alpine
 
   deploy:
     docker:

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,15 @@
+FROM maven:3.6-jdk-8
+
+WORKDIR /usr/src/app
+
+ADD . .
+
+RUN mvn package -Dmaven.test.skip=true
+
+FROM java:8-alpine
+
+COPY --from=0 /usr/src/app/target/ego-*-SNAPSHOT-exec.jar /usr/bin/ego.jar
+
+ENTRYPOINT ["java", "-jar", "/usr/bin/ego.jar"]
+
+EXPOSE 8081/tcp

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -9,6 +9,7 @@ RUN mvn package -Dmaven.test.skip=true
 FROM java:8-alpine
 
 COPY --from=0 /usr/src/app/target/ego-*-SNAPSHOT-exec.jar /usr/bin/ego.jar
+COPY --from=0 /usr/src/app/src/main/resources/flyway/sql /usr/src/flyway-migration-sql
 
 ENTRYPOINT ["java", "-jar", "/usr/bin/ego.jar"]
 


### PR DESCRIPTION
This Dockerfile.prod is created for deploying on Kubernetes (https://github.com/overture-stack/roadmap/issues/13).
- Its size is 225 MB (122 MB compressed) comparing to 1.11GB (497 Mb compressed) of current Dockerfile.
- The production docker image does not rely on `run.sh`. All spring configurations will be passed as environment variables(https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html).
- This docker image will be used by helm chart https://github.com/overture-stack/charts/tree/master/ego