### PR TITLE
Use pre established redirect url

### DIFF
--- a/src/main/java/bio/overture/ego/security/OAuth2ClientResources.java
+++ b/src/main/java/bio/overture/ego/security/OAuth2ClientResources.java
@@ -30,6 +30,10 @@ public class OAuth2ClientResources {
               session.setAttribute("ego_client_id", matcher.group(1));
             }
 
+            if (getPreEstablishedRedirectUri() != null) {
+              return getPreEstablishedRedirectUri();
+            }
+
             return new URI(
                     uri.getScheme(), uri.getAuthority(), uri.getPath(), null, uri.getFragment())
                 .toString();


### PR DESCRIPTION
If ego is behind a proxy, it will not figure out the redirect uri directly. In this case, we need to hard code pre established redirect url.