### PR TITLE
Enum fix

### DIFF
--- a/src/main/java/bio/overture/ego/config/UserDefaultsConfig.java
+++ b/src/main/java/bio/overture/ego/config/UserDefaultsConfig.java
@@ -1,0 +1,31 @@
+package bio.overture.ego.config;
+
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.model.enums.UserType;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import static bio.overture.ego.model.enums.StatusType.PENDING;
+import static bio.overture.ego.model.enums.StatusType.resolveStatusType;
+import static bio.overture.ego.model.enums.UserType.USER;
+import static bio.overture.ego.model.enums.UserType.resolveUserType;
+import static org.springframework.util.StringUtils.isEmpty;
+
+@Configuration
+public class UserDefaultsConfig {
+
+  @Getter
+  private final UserType defaultUserType;
+
+  @Getter
+  private final StatusType defaultUserStatus;
+
+  public UserDefaultsConfig(
+        @Value("${default.user.type}") String userType,
+        @Value("${default.user.status}") String userStatus) {
+    this.defaultUserType = isEmpty(userType) ? USER : resolveUserType(userType);
+    this.defaultUserStatus = isEmpty(userStatus) ? PENDING : resolveStatusType(userStatus);
+  }
+
+}

--- a/src/main/java/bio/overture/ego/model/dto/CreateApplicationRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/CreateApplicationRequest.java
@@ -17,6 +17,7 @@
 package bio.overture.ego.model.dto;
 
 import bio.overture.ego.model.enums.ApplicationType;
+import bio.overture.ego.model.enums.StatusType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,10 +29,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateApplicationRequest {
   private String name;
-  private ApplicationType applicationType;
+  private ApplicationType type;
   private String clientId;
   private String clientSecret;
   private String redirectUri;
   private String description;
-  private String status;
+  private StatusType status;
 }

--- a/src/main/java/bio/overture/ego/model/dto/CreateUserRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/CreateUserRequest.java
@@ -16,6 +16,9 @@
 
 package bio.overture.ego.model.dto;
 
+import bio.overture.ego.model.enums.LanguageType;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.model.enums.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,9 +30,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateUserRequest {
   private String email;
-  private String userType;
-  private String status;
+  private UserType type;
+  private StatusType status;
   private String firstName;
   private String lastName;
-  private String preferredLanguage;
+  private LanguageType preferredLanguage;
 }

--- a/src/main/java/bio/overture/ego/model/dto/GroupRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/GroupRequest.java
@@ -16,6 +16,7 @@
 
 package bio.overture.ego.model.dto;
 
+import bio.overture.ego.model.enums.StatusType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,5 +30,5 @@ public class GroupRequest {
 
   private String name;
   private String description;
-  private String status;
+  private StatusType status;
 }

--- a/src/main/java/bio/overture/ego/model/dto/UpdateApplicationRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/UpdateApplicationRequest.java
@@ -16,6 +16,8 @@
 
 package bio.overture.ego.model.dto;
 
+import bio.overture.ego.model.enums.ApplicationType;
+import bio.overture.ego.model.enums.StatusType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,9 +31,9 @@ public class UpdateApplicationRequest {
 
   private String name;
   private String clientId;
-  private String applicationType;
+  private ApplicationType type;
   private String clientSecret;
   private String redirectUri;
   private String description;
-  private String status;
+  private StatusType status;
 }

--- a/src/main/java/bio/overture/ego/model/dto/UpdateUserRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/UpdateUserRequest.java
@@ -16,11 +16,15 @@
 
 package bio.overture.ego.model.dto;
 
-import java.util.Date;
+import bio.overture.ego.model.enums.LanguageType;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.model.enums.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.Date;
 
 @Data
 @Builder
@@ -29,10 +33,10 @@ import lombok.NoArgsConstructor;
 public class UpdateUserRequest {
 
   private String email;
-  private String userType;
-  private String status;
+  private UserType type;
+  private StatusType status;
   private String firstName;
   private String lastName;
-  private String preferredLanguage;
+  private LanguageType preferredLanguage;
   private Date lastLogin;
 }

--- a/src/main/java/bio/overture/ego/model/entity/Application.java
+++ b/src/main/java/bio/overture/ego/model/entity/Application.java
@@ -16,24 +16,48 @@
 
 package bio.overture.ego.model.entity;
 
-import static com.google.common.collect.Sets.newHashSet;
-
-import bio.overture.ego.model.enums.*;
+import bio.overture.ego.model.enums.ApplicationType;
+import bio.overture.ego.model.enums.JavaFields;
+import bio.overture.ego.model.enums.LombokFields;
+import bio.overture.ego.model.enums.SqlFields;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.model.enums.Tables;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
-import java.util.Set;
-import java.util.UUID;
-import javax.persistence.*;
-import javax.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
+import javax.persistence.NamedSubgraph;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static com.google.common.collect.Sets.newHashSet;
 
 @Entity
 @Table(name = Tables.APPLICATION)
@@ -56,6 +80,7 @@ import org.hibernate.annotations.TypeDef;
   JavaFields.STATUS
 })
 @TypeDef(name = "application_type_enum", typeClass = PostgreSQLEnumType.class)
+@TypeDef(name = EGO_ENUM, typeClass = PostgreSQLEnumType.class)
 @JsonInclude(JsonInclude.Include.CUSTOM)
 @NamedEntityGraph(
     name = "application-entity-with-relationships",
@@ -89,11 +114,11 @@ public class Application implements Identifiable<UUID> {
   private String name;
 
   @NotNull
+  @Type(type = EGO_ENUM)
   @Enumerated(EnumType.STRING)
-  @Type(type = "application_type_enum")
-  @Column(name = SqlFields.APPLICATIONTYPE, nullable = false)
+  @Column(name = SqlFields.TYPE, nullable = false)
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
-  private ApplicationType applicationType;
+  private ApplicationType type;
 
   @NotNull
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
@@ -112,11 +137,12 @@ public class Application implements Identifiable<UUID> {
   @Column(name = SqlFields.DESCRIPTION)
   private String description;
 
-  // TODO: [rtisma] replace with Enum similar to AccessLevel
   @NotNull
+  @Type(type = EGO_ENUM)
+  @Enumerated(EnumType.STRING)
   @JsonView(Views.JWTAccessToken.class)
   @Column(name = SqlFields.STATUS, nullable = false)
-  private String status;
+  private StatusType status;
 
   @JsonIgnore
   @Builder.Default

--- a/src/main/java/bio/overture/ego/model/entity/Group.java
+++ b/src/main/java/bio/overture/ego/model/entity/Group.java
@@ -16,21 +16,31 @@
 
 package bio.overture.ego.model.entity;
 
-import static com.google.common.collect.Sets.newHashSet;
-
 import bio.overture.ego.model.enums.JavaFields;
 import bio.overture.ego.model.enums.LombokFields;
 import bio.overture.ego.model.enums.SqlFields;
+import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.model.enums.Tables;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
-import java.util.Set;
-import java.util.UUID;
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -43,13 +53,11 @@ import javax.persistence.NamedSubgraph;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.hibernate.annotations.GenericGenerator;
+import java.util.Set;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static com.google.common.collect.Sets.newHashSet;
 
 @Data
 @Entity
@@ -59,6 +67,7 @@ import org.hibernate.annotations.GenericGenerator;
 @Table(name = Tables.GROUP)
 @JsonView(Views.REST.class)
 @EqualsAndHashCode(of = {LombokFields.id})
+@TypeDef(name = EGO_ENUM, typeClass = PostgreSQLEnumType.class)
 @ToString(exclude = {LombokFields.users, LombokFields.applications, LombokFields.permissions})
 @JsonPropertyOrder({
   JavaFields.ID,
@@ -101,10 +110,11 @@ public class Group implements PolicyOwner, NameableEntity<UUID> {
   @Column(name = SqlFields.DESCRIPTION)
   private String description;
 
-  // TODO: [rtisma] replace with Enum similar to AccessLevel
   @NotNull
+  @Type(type = EGO_ENUM)
+  @Enumerated(EnumType.STRING)
   @Column(name = SqlFields.STATUS, nullable = false)
-  private String status;
+  private StatusType status;
 
   // TODO: [rtisma] rename this to groupPermissions.
   // Ensure anything using JavaFields.PERMISSIONS is also replaced with JavaFields.GROUPPERMISSIONS

--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -17,14 +17,18 @@
 package bio.overture.ego.model.entity;
 
 import bio.overture.ego.model.enums.JavaFields;
+import bio.overture.ego.model.enums.LanguageType;
 import bio.overture.ego.model.enums.LombokFields;
 import bio.overture.ego.model.enums.SqlFields;
+import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.model.enums.Tables;
+import bio.overture.ego.model.enums.UserType;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -33,10 +37,14 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -54,6 +62,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
 import static bio.overture.ego.service.UserService.resolveUsersPermissions;
 import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
 import static com.google.common.collect.Sets.newHashSet;
@@ -92,6 +101,7 @@ import static com.google.common.collect.Sets.newHashSet;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonView(Views.REST.class)
+@TypeDef(name = EGO_ENUM, typeClass = PostgreSQLEnumType.class)
 @NamedEntityGraph(
     name = "user-entity-with-relationships",
     attributeNodes = {
@@ -127,15 +137,18 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   private String email;
 
   @NotNull
-  @Column(name = SqlFields.USERTYPE, nullable = false)
+  @Type(type = EGO_ENUM)
+  @Enumerated(EnumType.STRING)
+  @Column(name = SqlFields.TYPE, nullable = false)
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
-  private String userType;
+  private UserType type;
 
-  // TODO: [rtisma] replace with Enum similar to AccessLevel
   @NotNull
+  @Type(type = EGO_ENUM)
+  @Enumerated(EnumType.STRING)
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
   @Column(name = SqlFields.STATUS, nullable = false)
-  private String status;
+  private StatusType status;
 
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
   @Column(name = SqlFields.FIRSTNAME)
@@ -154,10 +167,11 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   @Column(name = SqlFields.LASTLOGIN)
   private Date lastLogin;
 
-  // TODO: [rtisma] replace with Enum similar to AccessLevel
-  @JsonView({Views.JWTAccessToken.class, Views.REST.class})
+  @Type(type = EGO_ENUM)
+  @Enumerated(EnumType.STRING)
   @Column(name = SqlFields.PREFERREDLANGUAGE)
-  private String preferredLanguage;
+  @JsonView({Views.JWTAccessToken.class, Views.REST.class})
+  private LanguageType preferredLanguage;
 
   // TODO: [rtisma] test that always initialized with empty set
   @JsonIgnore

--- a/src/main/java/bio/overture/ego/model/enums/AccessLevel.java
+++ b/src/main/java/bio/overture/ego/model/enums/AccessLevel.java
@@ -16,10 +16,11 @@
 
 package bio.overture.ego.model.enums;
 
-import java.util.Arrays;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 public enum AccessLevel {
@@ -27,6 +28,7 @@ public enum AccessLevel {
   WRITE("WRITE"),
   DENY("DENY");
 
+  public static final String EGO_ENUM = "ego_enum";
   public static final String EGO_ACCESS_LEVEL_ENUM = "ego_access_level_enum";
 
   @NonNull private final String value;

--- a/src/main/java/bio/overture/ego/model/enums/LanguageType.java
+++ b/src/main/java/bio/overture/ego/model/enums/LanguageType.java
@@ -1,0 +1,17 @@
+package bio.overture.ego.model.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum LanguageType {
+
+  ENGLISH,
+  FRENCH,
+  SPANISH;
+
+  @Override
+  public String toString() {
+    return this.name();
+  }
+
+}

--- a/src/main/java/bio/overture/ego/model/enums/SqlFields.java
+++ b/src/main/java/bio/overture/ego/model/enums/SqlFields.java
@@ -1,8 +1,8 @@
 package bio.overture.ego.model.enums;
 
-import static lombok.AccessLevel.PRIVATE;
-
 import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @NoArgsConstructor(access = PRIVATE)
 public class SqlFields {
@@ -10,8 +10,7 @@ public class SqlFields {
   public static final String ID = "id";
   public static final String NAME = "name";
   public static final String EMAIL = "email";
-  public static final String USERTYPE = "usertype";
-  public static final String APPLICATIONTYPE = "applicationtype";
+  public static final String TYPE = "type";
   public static final String STATUS = "status";
   public static final String FIRSTNAME = "firstname";
   public static final String LASTNAME = "lastname";

--- a/src/main/java/bio/overture/ego/model/enums/StatusType.java
+++ b/src/main/java/bio/overture/ego/model/enums/StatusType.java
@@ -19,18 +19,33 @@ package bio.overture.ego.model.enums;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
-public enum EntityStatus {
-  APPROVED("Approved"),
-  DISABLED("Disabled"),
-  PENDING("Pending"),
-  REJECTED("Rejected"),
-  ;
+import static bio.overture.ego.utils.Joiners.COMMA;
+import static bio.overture.ego.utils.Streams.stream;
+import static java.lang.String.format;
 
-  @NonNull private final String value;
+@RequiredArgsConstructor
+public enum StatusType {
+
+  APPROVED,
+  DISABLED,
+  PENDING,
+  REJECTED;
+
+  public static StatusType resolveStatusType(@NonNull String statusType) {
+    return stream(values())
+        .filter(x -> x.toString().equals(statusType))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    format(
+                        "The status type '%s' cannot be resolved. Must be one of: [%s]",
+                        statusType, COMMA.join(values()))));
+  }
 
   @Override
   public String toString() {
-    return value;
+    return this.name();
   }
+
 }

--- a/src/main/java/bio/overture/ego/model/enums/UserType.java
+++ b/src/main/java/bio/overture/ego/model/enums/UserType.java
@@ -16,31 +16,33 @@
 
 package bio.overture.ego.model.enums;
 
-import static bio.overture.ego.utils.Streams.stream;
-import static java.lang.String.format;
-
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import static bio.overture.ego.utils.Joiners.COMMA;
+import static bio.overture.ego.utils.Streams.stream;
+import static java.lang.String.format;
+
 @RequiredArgsConstructor
 public enum UserType {
-  USER("USER"),
-  ADMIN("ADMIN");
+  USER,
+  ADMIN;
 
-  @NonNull private final String value;
-
-  @Override
-  public String toString() {
-    return value;
-  }
-
-  public static UserType resolveUserTypeIgnoreCase(@NonNull String userType) {
+  public static UserType resolveUserType(@NonNull String userType) {
     return stream(values())
-        .filter(x -> x.toString().equals(userType.toUpperCase()))
+        .filter(x -> x.toString().equals(userType))
         .findFirst()
         .orElseThrow(
             () ->
-                new IllegalStateException(
-                    format("The user applicationType '%s' cannot be resolved", userType)));
+                new IllegalArgumentException(
+                    format(
+                        "The user type '%s' cannot be resolved. Must be one of: [%s]",
+                        userType, COMMA.join(values()))));
   }
+
+  @Override
+  public String toString() {
+    return this.name();
+  }
+
 }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
@@ -20,11 +20,12 @@ import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Group;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.utils.QueryUtils;
-import java.util.UUID;
-import javax.persistence.criteria.Join;
 import lombok.NonNull;
 import lombok.val;
 import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.Join;
+import java.util.UUID;
 
 public class ApplicationSpecification extends SpecificationBase<Application> {
   public static Specification<Application> containsText(@NonNull String text) {

--- a/src/main/java/bio/overture/ego/repository/queryspecification/SpecificationBase.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/SpecificationBase.java
@@ -18,14 +18,15 @@ package bio.overture.ego.repository.queryspecification;
 
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.utils.QueryUtils;
-import java.util.Arrays;
-import java.util.List;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import lombok.NonNull;
 import lombok.val;
 import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.Arrays;
+import java.util.List;
 
 public class SpecificationBase<T> {
   protected static <T> Predicate[] getQueryPredicates(
@@ -44,7 +45,9 @@ public class SpecificationBase<T> {
       @NonNull String fieldName,
       String fieldValue) {
     val finalText = QueryUtils.prepareForQuery(fieldValue);
-    return builder.like(builder.lower(root.get(fieldName)), finalText);
+
+    // Cast "as" String so that we can search ENUM types
+    return builder.like(builder.lower(root.get(fieldName).as(String.class)), finalText);
   }
 
   public static <T> Specification<T> filterBy(@NonNull List<SearchFilter> filters) {

--- a/src/main/java/bio/overture/ego/security/SecureAuthorizationManager.java
+++ b/src/main/java/bio/overture/ego/security/SecureAuthorizationManager.java
@@ -24,13 +24,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.Authentication;
 
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.UserType.ADMIN;
+import static bio.overture.ego.model.enums.UserType.USER;
+
 @Slf4j
 @Profile("auth")
 public class SecureAuthorizationManager implements AuthorizationManager {
   public boolean authorize(@NonNull Authentication authentication) {
     log.info("Trying to authorize as user");
     User user = (User) authentication.getPrincipal();
-    return "user".equals(user.getUserType().toLowerCase()) && isActiveUser(user);
+    return user.getType() == USER && isActiveUser(user);
   }
 
   public boolean authorizeWithAdminRole(@NonNull Authentication authentication) {
@@ -39,11 +43,11 @@ public class SecureAuthorizationManager implements AuthorizationManager {
     if (authentication.getPrincipal() instanceof User) {
       User user = (User) authentication.getPrincipal();
       log.info("Trying to authorize user '" + user.getName() + "' as admin");
-      status = "admin".equals(user.getUserType().toLowerCase()) && isActiveUser(user);
+      status = user.getType() == ADMIN && isActiveUser(user);
     } else if (authentication.getPrincipal() instanceof Application) {
       Application application = (Application) authentication.getPrincipal();
       log.info("Trying to authorize application '" + application.getName() + "' as admin");
-      status = application.getApplicationType() == ApplicationType.ADMIN;
+      status = application.getType() == ApplicationType.ADMIN;
     } else {
       log.info("Unknown applicationType of authentication passed to authorizeWithAdminRole");
     }
@@ -64,6 +68,6 @@ public class SecureAuthorizationManager implements AuthorizationManager {
   }
 
   public boolean isActiveUser(User user) {
-    return "approved".equals(user.getStatus().toLowerCase());
+    return user.getStatus() == APPROVED;
   }
 }

--- a/src/main/java/bio/overture/ego/service/ApplicationService.java
+++ b/src/main/java/bio/overture/ego/service/ApplicationService.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static bio.overture.ego.model.enums.ApplicationStatus.APPROVED;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
 import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
 import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
 import static bio.overture.ego.token.app.AppTokenClaims.AUTHORIZED_GRANTS;
@@ -195,7 +195,7 @@ public class ApplicationService extends AbstractNamedService<Application, UUID>
 
     val application = getByClientId(clientId);
 
-    if (!application.getStatus().equals(APPROVED.toString())) {
+    if (application.getStatus() != APPROVED) {
       throw new ClientRegistrationException("Client Access is not approved.");
     }
 

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -23,7 +23,6 @@ import bio.overture.ego.model.dto.UserScopesResponse;
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Token;
 import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.enums.ApplicationType;
 import bio.overture.ego.model.exceptions.NotFoundException;
 import bio.overture.ego.model.params.ScopeName;
 import bio.overture.ego.reactor.events.UserEvents;
@@ -43,17 +42,6 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import java.security.InvalidKeyException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -76,9 +64,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static bio.overture.ego.model.dto.Scope.effectiveScopes;
 import static bio.overture.ego.model.dto.Scope.explicitScopes;
+import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
 import static bio.overture.ego.service.UserService.extractScopes;
 import static bio.overture.ego.utils.CollectionUtils.mapToSet;
 import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
@@ -405,7 +395,7 @@ public class TokenService extends AbstractNamedService<Token, UUID> {
   }
 
   private void revokeTokenAsApplication(String tokenName, Application application) {
-    if (application.getApplicationType().equals(ApplicationType.ADMIN)) {
+    if (application.getType() == ADMIN) {
       revoke(tokenName);
     } else {
       throw new InvalidRequestException(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,7 +121,7 @@ token:
 default:
   user:
     type: USER
-    status: Approved
+    status: APPROVED
 ---
 ###############################################################################
 # Profile - "jks"

--- a/src/main/resources/flyway/sql/V1_9__new_enum_types.sql
+++ b/src/main/resources/flyway/sql/V1_9__new_enum_types.sql
@@ -1,0 +1,38 @@
+-- Create new types
+CREATE TYPE statustype AS ENUM('Approved', 'Rejected', 'Disabled', 'Pending');
+CREATE TYPE usertype AS ENUM('USER', 'ADMIN');
+CREATE TYPE languagetype AS ENUM('English', 'French', 'Spanish');
+
+-- Update Users status column to be of type statustype
+ALTER TABLE egouser DROP CONSTRAINT egouser_status_check;
+ALTER TABLE egouser ALTER COLUMN status TYPE statustype USING status::statustype;
+ALTER TABLE egouser ALTER COLUMN status SET NOT NULL;
+ALTER TABLE egouser ALTER COLUMN status SET DEFAULT 'Pending';
+
+-- Update Applications status column to be of type statustype
+ALTER TABLE egoapplication DROP CONSTRAINT egoapplication_status_check;
+ALTER TABLE egoapplication ALTER COLUMN status TYPE statustype USING status::statustype;
+ALTER TABLE egoapplication ALTER COLUMN status SET NOT NULL;
+ALTER TABLE egoapplication ALTER COLUMN status SET DEFAULT 'Pending';
+
+-- Update Group status column to be of type statustype
+ALTER TABLE egogroup DROP CONSTRAINT egogroup_status_check;
+ALTER TABLE egogroup ALTER COLUMN status TYPE statustype USING status::statustype;
+ALTER TABLE egogroup ALTER COLUMN status SET NOT NULL;
+ALTER TABLE egogroup ALTER COLUMN status SET DEFAULT 'Pending';
+
+-- Change usertype to type since it is redundant in context of an user
+ALTER TABLE egouser RENAME usertype TO type;
+
+-- Change the type of column type to usertype enum
+ALTER TABLE egouser ALTER COLUMN type TYPE usertype USING type::usertype;
+ALTER TABLE egouser ALTER COLUMN type SET NOT NULL;
+ALTER TABLE egouser ALTER COLUMN type SET DEFAULT 'USER';
+
+-- Change the type of column preferredlanguage to languagetype enum
+ALTER TABLE egouser DROP CONSTRAINT egouser_preferredlanguage_check;
+ALTER TABLE egouser ALTER COLUMN preferredlanguage TYPE languagetype USING preferredlanguage::languagetype;
+
+-- Change applicationtype to type since it is redundant in context of an application
+ALTER TABLE egoapplication RENAME applicationtype TO type;
+

--- a/src/main/resources/flyway/sql/V1_9__new_enum_types.sql
+++ b/src/main/resources/flyway/sql/V1_9__new_enum_types.sql
@@ -1,38 +1,59 @@
 -- Create new types
-CREATE TYPE statustype AS ENUM('Approved', 'Rejected', 'Disabled', 'Pending');
+CREATE TYPE statustype AS ENUM('APPROVED', 'REJECTED', 'DISABLED', 'PENDING');
 CREATE TYPE usertype AS ENUM('USER', 'ADMIN');
-CREATE TYPE languagetype AS ENUM('English', 'French', 'Spanish');
+CREATE TYPE languagetype AS ENUM('ENGLISH', 'FRENCH', 'SPANISH');
 
--- Update Users status column to be of type statustype
+-- Convert the Users status column to be of type statustype
 ALTER TABLE egouser DROP CONSTRAINT egouser_status_check;
+UPDATE egouser SET status = 'APPROVED' WHERE status = 'Approved';
+UPDATE egouser SET status = 'REJECTED' WHERE status = 'Rejected';
+UPDATE egouser SET status = 'DISABLED' WHERE status = 'Disabled';
+UPDATE egouser SET status = 'PENDING'  WHERE status = 'Pending';
 ALTER TABLE egouser ALTER COLUMN status TYPE statustype USING status::statustype;
 ALTER TABLE egouser ALTER COLUMN status SET NOT NULL;
-ALTER TABLE egouser ALTER COLUMN status SET DEFAULT 'Pending';
+ALTER TABLE egouser ALTER COLUMN status SET DEFAULT 'PENDING';
 
--- Update Applications status column to be of type statustype
+-- Convert the Applications status column to be of type statustype
 ALTER TABLE egoapplication DROP CONSTRAINT egoapplication_status_check;
+UPDATE egoapplication SET status = 'APPROVED' WHERE status = 'Approved';
+UPDATE egoapplication SET status = 'REJECTED' WHERE status = 'Rejected';
+UPDATE egoapplication SET status = 'DISABLED' WHERE status = 'Disabled';
+UPDATE egoapplication SET status = 'PENDING'  WHERE status = 'Pending' OR status IS NULL;
 ALTER TABLE egoapplication ALTER COLUMN status TYPE statustype USING status::statustype;
 ALTER TABLE egoapplication ALTER COLUMN status SET NOT NULL;
-ALTER TABLE egoapplication ALTER COLUMN status SET DEFAULT 'Pending';
+ALTER TABLE egoapplication ALTER COLUMN status SET DEFAULT 'PENDING';
 
--- Update Group status column to be of type statustype
+-- Convert the Group 'status' column to be of type statustype
 ALTER TABLE egogroup DROP CONSTRAINT egogroup_status_check;
+UPDATE egogroup SET status = 'APPROVED' WHERE status = 'Approved';
+UPDATE egogroup SET status = 'REJECTED' WHERE status = 'Rejected';
+UPDATE egogroup SET status = 'DISABLED' WHERE status = 'Disabled';
+UPDATE egogroup SET status = 'PENDING'  WHERE status = 'Pending';
 ALTER TABLE egogroup ALTER COLUMN status TYPE statustype USING status::statustype;
 ALTER TABLE egogroup ALTER COLUMN status SET NOT NULL;
-ALTER TABLE egogroup ALTER COLUMN status SET DEFAULT 'Pending';
+ALTER TABLE egogroup ALTER COLUMN status SET DEFAULT 'PENDING';
 
--- Change usertype to type since it is redundant in context of an user
+-- Rename the User 'usertype' column to 'type' since 'usertype' is redundant in the context of a user
 ALTER TABLE egouser RENAME usertype TO type;
 
--- Change the type of column type to usertype enum
+-- Change the User 'type' column to be of type usertype
 ALTER TABLE egouser ALTER COLUMN type TYPE usertype USING type::usertype;
 ALTER TABLE egouser ALTER COLUMN type SET NOT NULL;
 ALTER TABLE egouser ALTER COLUMN type SET DEFAULT 'USER';
 
--- Change the type of column preferredlanguage to languagetype enum
+-- Convert the User 'preferredlanguage' column to be of type languagetype
 ALTER TABLE egouser DROP CONSTRAINT egouser_preferredlanguage_check;
+UPDATE egouser SET preferredlanguage = 'ENGLISH' WHERE preferredlanguage = 'English';
+UPDATE egouser SET preferredlanguage = 'FRENCH' WHERE preferredlanguage = 'French';
+UPDATE egouser SET preferredlanguage = 'SPANISH' WHERE preferredlanguage = 'Spanish';
 ALTER TABLE egouser ALTER COLUMN preferredlanguage TYPE languagetype USING preferredlanguage::languagetype;
 
--- Change applicationtype to type since it is redundant in context of an application
+-- Rename the Application 'applicationtype' column to 'type' since 'applicationtype' is redundant in the context of an application
 ALTER TABLE egoapplication RENAME applicationtype TO type;
+
+-- Add default uuid4 generation to other tables just like for Application and Group
+ALTER TABLE egouser ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE policy ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE grouppermission ALTER COLUMN id SET DEFAULT uuid_generate_v4();
+ALTER TABLE userpermission ALTER COLUMN id SET DEFAULT uuid_generate_v4();
 

--- a/src/test/java/bio/overture/ego/controller/AbstractPermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/AbstractPermissionControllerTest.java
@@ -1,5 +1,31 @@
 package bio.overture.ego.controller;
 
+import bio.overture.ego.model.dto.PermissionRequest;
+import bio.overture.ego.model.entity.AbstractPermission;
+import bio.overture.ego.model.entity.Identifiable;
+import bio.overture.ego.model.entity.NameableEntity;
+import bio.overture.ego.model.entity.Policy;
+import bio.overture.ego.model.enums.AccessLevel;
+import bio.overture.ego.service.AbstractPermissionService;
+import bio.overture.ego.service.NamedService;
+import bio.overture.ego.service.PolicyService;
+import bio.overture.ego.utils.EntityGenerator;
+import bio.overture.ego.utils.Streams;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
 import static bio.overture.ego.model.enums.AccessLevel.DENY;
 import static bio.overture.ego.model.enums.AccessLevel.WRITE;
 import static bio.overture.ego.utils.CollectionUtils.mapToList;
@@ -19,31 +45,6 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
-
-import bio.overture.ego.model.dto.PermissionRequest;
-import bio.overture.ego.model.entity.AbstractPermission;
-import bio.overture.ego.model.entity.Identifiable;
-import bio.overture.ego.model.entity.NameableEntity;
-import bio.overture.ego.model.entity.Policy;
-import bio.overture.ego.model.enums.AccessLevel;
-import bio.overture.ego.service.AbstractPermissionService;
-import bio.overture.ego.service.NamedService;
-import bio.overture.ego.service.PolicyService;
-import bio.overture.ego.utils.EntityGenerator;
-import bio.overture.ego.utils.Streams;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Sets;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.IntStream;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.junit.Test;
-import org.springframework.http.HttpStatus;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 @Slf4j
 public abstract class AbstractPermissionControllerTest<
@@ -128,7 +129,7 @@ public abstract class AbstractPermissionControllerTest<
 
     // Add all the permissions, including the one before
     val r2 =
-        initRequest(getOwnerType())
+        initStringRequest()
             .endpoint(getAddPermissionsEndpoint(owner1.getId()))
             .body(permissionRequests)
             .post();
@@ -153,7 +154,7 @@ public abstract class AbstractPermissionControllerTest<
 
     log.info("Add the same permissions to the owner. This means duplicates are being added");
     val r2 =
-        initRequest(getOwnerType())
+        initStringRequest()
             .endpoint(getAddPermissionsEndpoint(owner1.getId()))
             .body(permissionRequests)
             .post();

--- a/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
@@ -17,8 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.enums.ApplicationType;
@@ -34,6 +32,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -70,8 +71,8 @@ public class ApplicationControllerTest extends AbstractControllerTest {
             .clientId("addApplication_Success")
             .clientSecret("addApplication_Success")
             .redirectUri("http://example.com")
-            .status("Approved")
-            .applicationType(ApplicationType.CLIENT)
+            .status(APPROVED)
+            .type(ApplicationType.CLIENT)
             .build();
 
     val response = initStringRequest().endpoint("/applications").body(app).post();
@@ -91,8 +92,8 @@ public class ApplicationControllerTest extends AbstractControllerTest {
             .clientId("addDuplicateApplication")
             .clientSecret("addDuplicateApplication")
             .redirectUri("http://example.com")
-            .status("Approved")
-            .applicationType(ApplicationType.CLIENT)
+            .status(APPROVED)
+            .type(ApplicationType.CLIENT)
             .build();
 
     val app2 =
@@ -101,8 +102,8 @@ public class ApplicationControllerTest extends AbstractControllerTest {
             .clientId("addDuplicateApplication")
             .clientSecret("addDuplicateApplication")
             .redirectUri("http://example.com")
-            .status("Approved")
-            .applicationType(ApplicationType.CLIENT)
+            .status(APPROVED)
+            .type(ApplicationType.CLIENT)
             .build();
 
     val response1 = initStringRequest().endpoint("/applications").body(app1).post();
@@ -126,6 +127,6 @@ public class ApplicationControllerTest extends AbstractControllerTest {
 
     assertThat(responseStatus).isEqualTo(HttpStatus.OK);
     assertThat(responseJson.get("name").asText()).isEqualTo("Application 111111");
-    assertThat(responseJson.get("applicationType").asText()).isEqualTo("CLIENT");
+    assertThat(responseJson.get("type").asText()).isEqualTo("CLIENT");
   }
 }

--- a/src/test/java/bio/overture/ego/controller/GroupControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/GroupControllerTest.java
@@ -1,24 +1,11 @@
 package bio.overture.ego.controller;
 
-import static bio.overture.ego.utils.EntityTools.extractAppIds;
-import static bio.overture.ego.utils.EntityTools.extractGroupIds;
-import static bio.overture.ego.utils.EntityTools.extractIDs;
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_ARRAY_ITEMS;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.enums.EntityStatus;
 import bio.overture.ego.service.ApplicationService;
 import bio.overture.ego.service.GroupService;
 import bio.overture.ego.service.UserService;
 import bio.overture.ego.utils.EntityGenerator;
-import java.util.UUID;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -30,6 +17,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.StatusType.PENDING;
+import static bio.overture.ego.utils.EntityTools.extractAppIds;
+import static bio.overture.ego.utils.EntityTools.extractGroupIds;
+import static bio.overture.ego.utils.EntityTools.extractIDs;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_ARRAY_ITEMS;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -64,7 +65,7 @@ public class GroupControllerTest extends AbstractControllerTest {
     val group =
         Group.builder()
             .name("Wizards")
-            .status(EntityStatus.PENDING.toString())
+            .status(PENDING)
             .description("")
             .build();
 
@@ -94,7 +95,7 @@ public class GroupControllerTest extends AbstractControllerTest {
     val responseBody = response.getBody();
     val expected =
         format(
-            "{\"id\":\"%s\",\"name\":\"Group One\",\"description\":\"\",\"status\":\"Pending\"}",
+            "{\"id\":\"%s\",\"name\":\"Group One\",\"description\":\"\",\"status\":\"PENDING\"}",
             groupId);
 
     assertThat(responseStatus).isEqualTo(HttpStatus.OK);
@@ -122,7 +123,7 @@ public class GroupControllerTest extends AbstractControllerTest {
 
     val expected =
         format(
-            "[{\"id\":\"%s\",\"name\":\"Group One\",\"description\":\"\",\"status\":\"Pending\"}, {\"id\":\"%s\",\"name\":\"Group Two\",\"description\":\"\",\"status\":\"Pending\"}, {\"id\":\"%s\",\"name\":\"Group Three\",\"description\":\"\",\"status\":\"Pending\"}]",
+            "[{\"id\":\"%s\",\"name\":\"Group One\",\"description\":\"\",\"status\":\"PENDING\"}, {\"id\":\"%s\",\"name\":\"Group Two\",\"description\":\"\",\"status\":\"PENDING\"}, {\"id\":\"%s\",\"name\":\"Group Three\",\"description\":\"\",\"status\":\"PENDING\"}]",
             groupService.getByName("Group One").getId(),
             groupService.getByName("Group Two").getId(),
             groupService.getByName("Group Three").getId());

--- a/src/test/java/bio/overture/ego/controller/MappingSanityTest.java
+++ b/src/test/java/bio/overture/ego/controller/MappingSanityTest.java
@@ -1,13 +1,10 @@
 package bio.overture.ego.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.entity.Group;
 import bio.overture.ego.model.entity.GroupPermission;
 import bio.overture.ego.model.entity.Policy;
 import bio.overture.ego.model.enums.AccessLevel;
-import bio.overture.ego.model.enums.ApplicationStatus;
 import bio.overture.ego.repository.GroupPermissionRepository;
 import bio.overture.ego.repository.GroupRepository;
 import bio.overture.ego.repository.PolicyRepository;
@@ -21,6 +18,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -39,7 +39,7 @@ public class MappingSanityTest {
   public void sanityCRUD_GroupPermissions() {
     // Create group
     val group =
-        Group.builder().name("myGroup").status(ApplicationStatus.APPROVED.toString()).build();
+        Group.builder().name("myGroup").status(APPROVED).build();
     groupRepository.save(group);
 
     // Create policy

--- a/src/test/java/bio/overture/ego/controller/UserControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserControllerTest.java
@@ -17,13 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import static bio.overture.ego.utils.Collectors.toImmutableList;
-import static bio.overture.ego.utils.EntityTools.extractUserIds;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.service.ApplicationService;
@@ -32,7 +25,6 @@ import bio.overture.ego.service.UserService;
 import bio.overture.ego.utils.EntityGenerator;
 import bio.overture.ego.utils.Streams;
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.UUID;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -43,6 +35,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.LanguageType.ENGLISH;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.StatusType.REJECTED;
+import static bio.overture.ego.model.enums.UserType.USER;
+import static bio.overture.ego.utils.Collectors.toImmutableList;
+import static bio.overture.ego.utils.EntityTools.extractUserIds;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -80,9 +85,9 @@ public class UserControllerTest extends AbstractControllerTest {
             .firstName("foo")
             .lastName("bar")
             .email("foobar@foo.bar")
-            .preferredLanguage("English")
-            .userType("USER")
-            .status("Approved")
+            .preferredLanguage(ENGLISH)
+            .type(USER)
+            .status(APPROVED)
             .build();
 
     val response = initStringRequest().endpoint("/users").body(user).post();
@@ -98,18 +103,18 @@ public class UserControllerTest extends AbstractControllerTest {
             .firstName("unique")
             .lastName("unique")
             .email("unique@unique.com")
-            .preferredLanguage("English")
-            .userType("USER")
-            .status("Approved")
+            .preferredLanguage(ENGLISH)
+            .type(USER)
+            .status(APPROVED)
             .build();
     val user2 =
         User.builder()
             .firstName("unique")
             .lastName("unique")
             .email("unique@unique.com")
-            .preferredLanguage("English")
-            .userType("USER")
-            .status("Approved")
+            .preferredLanguage(ENGLISH)
+            .type(USER)
+            .status(APPROVED)
             .build();
 
     val response1 = initStringRequest().endpoint("/users").body(user1).post();
@@ -138,8 +143,8 @@ public class UserControllerTest extends AbstractControllerTest {
     assertThat(responseJson.get("firstName").asText()).isEqualTo("First");
     assertThat(responseJson.get("lastName").asText()).isEqualTo("User");
     assertThat(responseJson.get("name").asText()).isEqualTo("FirstUser@domain.com");
-    assertThat(responseJson.get("preferredLanguage").asText()).isEqualTo("English");
-    assertThat(responseJson.get("status").asText()).isEqualTo("Approved");
+    assertThat(responseJson.get("preferredLanguage").asText()).isEqualTo(ENGLISH.toString());
+    assertThat(responseJson.get("status").asText()).isEqualTo(APPROVED.toString());
     assertThat(responseJson.get("id").asText()).isEqualTo(userId.toString());
   }
 
@@ -195,7 +200,7 @@ public class UserControllerTest extends AbstractControllerTest {
   @Test
   public void updateUser() {
     val user = entityGenerator.setupUser("update test");
-    val update = User.builder().id(user.getId()).status("Rejected").build();
+    val update = User.builder().id(user.getId()).status(REJECTED).build();
 
     val response = initStringRequest().endpoint("/users/%s", user.getId()).body(update).put();
 
@@ -204,7 +209,7 @@ public class UserControllerTest extends AbstractControllerTest {
     HttpStatus responseStatus = response.getStatusCode();
     assertThat(responseStatus).isEqualTo(HttpStatus.OK);
     assertThatJson(responseBody).node("id").isEqualTo(user.getId());
-    assertThatJson(responseBody).node("status").isEqualTo("Rejected");
+    assertThatJson(responseBody).node("status").isEqualTo(REJECTED.toString());
   }
 
   @Test

--- a/src/test/java/bio/overture/ego/selenium/LoadAdminUITest.java
+++ b/src/test/java/bio/overture/ego/selenium/LoadAdminUITest.java
@@ -17,16 +17,17 @@
 
 package bio.overture.ego.selenium;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.model.dto.CreateApplicationRequest;
-import bio.overture.ego.model.enums.ApplicationType;
 import bio.overture.ego.service.ApplicationService;
 import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LoadAdminUITest extends AbstractSeleniumTest {
 
@@ -47,8 +48,8 @@ public class LoadAdminUITest extends AbstractSeleniumTest {
             .clientSecret("seleniumSecret")
             .name("Selenium Tests")
             .redirectUri("http://localhost:" + uiPort)
-            .applicationType(ApplicationType.ADMIN)
-            .status("Approved")
+            .type(ADMIN)
+            .status(APPROVED)
             .description("testing")
             .build());
 

--- a/src/test/java/bio/overture/ego/service/GroupsServiceTest.java
+++ b/src/test/java/bio/overture/ego/service/GroupsServiceTest.java
@@ -4,7 +4,6 @@ import bio.overture.ego.controller.resolver.PageableResolver;
 import bio.overture.ego.model.dto.GroupRequest;
 import bio.overture.ego.model.dto.PermissionRequest;
 import bio.overture.ego.model.entity.AbstractPermission;
-import bio.overture.ego.model.enums.EntityStatus;
 import bio.overture.ego.model.exceptions.NotFoundException;
 import bio.overture.ego.model.exceptions.UniqueViolationException;
 import bio.overture.ego.model.search.SearchFilter;
@@ -30,6 +29,8 @@ import java.util.stream.Collectors;
 import static bio.overture.ego.model.enums.AccessLevel.DENY;
 import static bio.overture.ego.model.enums.AccessLevel.READ;
 import static bio.overture.ego.model.enums.AccessLevel.WRITE;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.StatusType.PENDING;
 import static bio.overture.ego.utils.EntityGenerator.generateNonExistentId;
 import static bio.overture.ego.utils.EntityTools.extractGroupNames;
 import static com.google.common.collect.Lists.newArrayList;
@@ -63,7 +64,7 @@ public class GroupsServiceTest {
 
   @Test
   public void uniqueNameCheck_CreateGroup_ThrowsUniqueConstraintException() {
-    val r1 = GroupRequest.builder().name(UUID.randomUUID().toString()).status("Pending").build();
+    val r1 = GroupRequest.builder().name(UUID.randomUUID().toString()).status(PENDING).build();
 
     val g1 = groupService.create(r1);
     assertThat(groupService.isExist(g1.getId())).isTrue();
@@ -77,9 +78,9 @@ public class GroupsServiceTest {
   public void uniqueClientIdCheck_UpdateGroup_ThrowsUniqueConstraintException() {
     val name1 = UUID.randomUUID().toString();
     val name2 = UUID.randomUUID().toString();
-    val cr1 = GroupRequest.builder().name(name1).status("Pending").build();
+    val cr1 = GroupRequest.builder().name(name1).status(PENDING).build();
 
-    val cr2 = GroupRequest.builder().name(name2).status("Approved").build();
+    val cr2 = GroupRequest.builder().name(name2).status(APPROVED).build();
 
     val g1 = groupService.create(cr1);
     assertThat(groupService.isExist(g1.getId())).isTrue();
@@ -436,7 +437,7 @@ public class GroupsServiceTest {
     val nonExistentEntity =
         GroupRequest.builder()
             .name("NonExistent")
-            .status(EntityStatus.PENDING.toString())
+            .status(PENDING)
             .description("")
             .build();
     assertThatExceptionOfType(NotFoundException.class)

--- a/src/test/java/bio/overture/ego/token/RevokeTokenTest.java
+++ b/src/test/java/bio/overture/ego/token/RevokeTokenTest.java
@@ -1,13 +1,9 @@
 package bio.overture.ego.token;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.service.TokenService;
 import bio.overture.ego.utils.EntityGenerator;
 import bio.overture.ego.utils.TestData;
-import java.util.HashSet;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Before;
@@ -22,6 +18,13 @@ import org.springframework.security.oauth2.common.exceptions.InvalidTokenExcepti
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.UserType.ADMIN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @Slf4j
 @SpringBootTest
@@ -51,8 +54,8 @@ public class RevokeTokenTest {
     applications.add(test.score);
 
     entityGenerator.setupToken(test.user1, adminTokenString, 1000, scopes, applications);
-    test.user1.setUserType("ADMIN");
-    test.user1.setStatus("Approved");
+    test.user1.setType(ADMIN);
+    test.user1.setStatus(APPROVED);
 
     val randomTokenString = "891044a1-3ffd-4164-a6a0-0e1e666b28dc";
     val randomToken =
@@ -76,8 +79,8 @@ public class RevokeTokenTest {
 
     val adminToken =
         entityGenerator.setupToken(test.user1, tokenString, 1000, scopes, applications);
-    test.user1.setUserType("ADMIN");
-    test.user1.setStatus("Approved");
+    test.user1.setType(ADMIN);
+    test.user1.setStatus(APPROVED);
 
     assertFalse(adminToken.isRevoked());
 

--- a/src/test/java/bio/overture/ego/utils/EntityGenerator.java
+++ b/src/test/java/bio/overture/ego/utils/EntityGenerator.java
@@ -1,12 +1,5 @@
 package bio.overture.ego.utils;
 
-import static bio.overture.ego.utils.CollectionUtils.listOf;
-import static bio.overture.ego.utils.CollectionUtils.mapToList;
-import static bio.overture.ego.utils.Splitters.COMMA_SPLITTER;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.model.dto.CreateApplicationRequest;
 import bio.overture.ego.model.dto.CreateUserRequest;
 import bio.overture.ego.model.dto.GroupRequest;
@@ -18,9 +11,7 @@ import bio.overture.ego.model.entity.Policy;
 import bio.overture.ego.model.entity.Token;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.entity.UserPermission;
-import bio.overture.ego.model.enums.ApplicationStatus;
 import bio.overture.ego.model.enums.ApplicationType;
-import bio.overture.ego.model.enums.EntityStatus;
 import bio.overture.ego.model.params.ScopeName;
 import bio.overture.ego.service.ApplicationService;
 import bio.overture.ego.service.BaseService;
@@ -32,6 +23,11 @@ import bio.overture.ego.service.TokenStoreService;
 import bio.overture.ego.service.UserPermissionService;
 import bio.overture.ego.service.UserService;
 import com.google.common.collect.ImmutableSet;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
@@ -40,10 +36,17 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+
+import static bio.overture.ego.model.enums.LanguageType.ENGLISH;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.StatusType.PENDING;
+import static bio.overture.ego.model.enums.UserType.ADMIN;
+import static bio.overture.ego.utils.CollectionUtils.listOf;
+import static bio.overture.ego.utils.CollectionUtils.mapToList;
+import static bio.overture.ego.utils.Splitters.COMMA_SPLITTER;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Component
 /**
@@ -71,10 +74,10 @@ public class EntityGenerator {
   private CreateApplicationRequest createApplicationCreateRequest(String clientId) {
     return CreateApplicationRequest.builder()
         .name(createApplicationName(clientId))
-        .applicationType(ApplicationType.CLIENT)
+        .type(ApplicationType.CLIENT)
         .clientId(clientId)
         .clientSecret(reverse(clientId))
-        .status(ApplicationStatus.PENDING.toString())
+        .status(PENDING)
         .build();
   }
 
@@ -122,10 +125,10 @@ public class EntityGenerator {
               val request =
                   CreateApplicationRequest.builder()
                       .name(clientId)
-                      .applicationType(applicationType)
+                      .type(applicationType)
                       .clientSecret(clientSecret)
                       .clientId(clientId)
-                      .status(ApplicationStatus.APPROVED.toString())
+                      .status(APPROVED)
                       .build();
               return applicationService.create(request);
             });
@@ -136,9 +139,9 @@ public class EntityGenerator {
         .email(String.format("%s%s@domain.com", firstName, lastName))
         .firstName(firstName)
         .lastName(lastName)
-        .status("Approved")
-        .preferredLanguage("English")
-        .userType("ADMIN")
+        .status(APPROVED)
+        .preferredLanguage(ENGLISH)
+        .type(ADMIN)
         .build();
   }
 
@@ -170,7 +173,7 @@ public class EntityGenerator {
   private GroupRequest createGroupRequest(String name) {
     return GroupRequest.builder()
         .name(name)
-        .status(EntityStatus.PENDING.toString())
+        .status(PENDING)
         .description("")
         .build();
   }

--- a/src/test/java/bio/overture/ego/utils/TestData.java
+++ b/src/test/java/bio/overture/ego/utils/TestData.java
@@ -1,19 +1,22 @@
 package bio.overture.ego.utils;
 
-import static bio.overture.ego.utils.CollectionUtils.listOf;
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
-
 import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Policy;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.enums.ApplicationType;
 import bio.overture.ego.model.params.ScopeName;
+import lombok.val;
+
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import lombok.val;
+
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.UserType.USER;
+import static bio.overture.ego.utils.CollectionUtils.listOf;
+import static bio.overture.ego.utils.CollectionUtils.mapToSet;
 
 public class TestData {
   public Application song;
@@ -59,8 +62,8 @@ public class TestData {
     entityGenerator.addPermissions(user2, getScopes("song.READ", "collab.READ", "id.WRITE"));
 
     regularUser = entityGenerator.setupUser("Regular User");
-    regularUser.setUserType("USER");
-    regularUser.setStatus("Approved");
+    regularUser.setType(USER);
+    regularUser.setStatus(APPROVED);
     entityGenerator.addPermissions(regularUser, getScopes("song.READ", "collab.READ"));
   }
 


### PR DESCRIPTION
Accompanying change for ui can be found in
https://github.com/overture-stack/ego-ui/pull/24

Changes:
- status field in Application, Group, User are now enums, both in application and db layer
- userType is renamed to type and is in both application and db layer
- applicationType is renamted to type and is in both application and db layer
- preferredlanguage is now an enum both in application and db layer
- create migration script to honour new enum values
- updated tests to reference enums instead of strings
