### PR TITLE
Ego 330 convert user application

### DIFF
--- a/src/main/java/bio/overture/ego/controller/UserController.java
+++ b/src/main/java/bio/overture/ego/controller/UserController.java
@@ -16,12 +16,6 @@
 
 package bio.overture.ego.controller;
 
-import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
-import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
-import static bio.overture.ego.controller.resolver.PageableResolver.SORT;
-import static bio.overture.ego.controller.resolver.PageableResolver.SORTORDER;
-import static org.springframework.util.StringUtils.isEmpty;
-
 import bio.overture.ego.model.dto.CreateUserRequest;
 import bio.overture.ego.model.dto.PageDTO;
 import bio.overture.ego.model.dto.PermissionRequest;
@@ -45,8 +39,6 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import java.util.List;
-import java.util.UUID;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +55,15 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
+import java.util.UUID;
+
+import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
+import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
+import static bio.overture.ego.controller.resolver.PageableResolver.SORT;
+import static bio.overture.ego.controller.resolver.PageableResolver.SORTORDER;
+import static org.springframework.util.StringUtils.isEmpty;
 
 @Slf4j
 @RestController
@@ -386,18 +387,18 @@ public class UserController {
   public @ResponseBody User addApplicationsToUser(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "id", required = true) UUID id,
-      @RequestBody(required = true) List<UUID> appIds) {
-    return userService.addUserToApps(id, appIds);
+      @RequestBody(required = true) List<UUID> applicationIds) {
+    return userService.associateApplicationsWithUser(id, applicationIds);
   }
 
   @AdminScoped
-  @RequestMapping(method = RequestMethod.DELETE, value = "/{id}/applications/{appIds}")
+  @RequestMapping(method = RequestMethod.DELETE, value = "/{id}/applications/{applicationIds}")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Delete Applications from User")})
   @ResponseStatus(value = HttpStatus.OK)
   public void deleteApplicationsFromUser(
       @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = true) final String accessToken,
       @PathVariable(value = "id", required = true) UUID id,
-      @PathVariable(value = "appIds", required = true) List<UUID> appIds) {
-    userService.deleteUserFromApps(id, appIds);
+      @PathVariable(value = "applicationIds", required = true) List<UUID> applicationIds) {
+    userService.disassociateApplicationsFromUser(id, applicationIds);
   }
 }

--- a/src/main/java/bio/overture/ego/controller/UserController.java
+++ b/src/main/java/bio/overture/ego/controller/UserController.java
@@ -16,6 +16,12 @@
 
 package bio.overture.ego.controller;
 
+import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
+import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
+import static bio.overture.ego.controller.resolver.PageableResolver.SORT;
+import static bio.overture.ego.controller.resolver.PageableResolver.SORTORDER;
+import static org.springframework.util.StringUtils.isEmpty;
+
 import bio.overture.ego.model.dto.CreateUserRequest;
 import bio.overture.ego.model.dto.PageDTO;
 import bio.overture.ego.model.dto.PermissionRequest;
@@ -39,6 +45,8 @@ import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.UUID;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,15 +63,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
-
-import java.util.List;
-import java.util.UUID;
-
-import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
-import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
-import static bio.overture.ego.controller.resolver.PageableResolver.SORT;
-import static bio.overture.ego.controller.resolver.PageableResolver.SORTORDER;
-import static org.springframework.util.StringUtils.isEmpty;
 
 @Slf4j
 @RestController

--- a/src/main/java/bio/overture/ego/model/dto/UpdateUserRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/UpdateUserRequest.java
@@ -19,7 +19,6 @@ package bio.overture.ego.model.dto;
 import bio.overture.ego.model.enums.LanguageType;
 import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.model.enums.UserType;
-import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -37,5 +36,4 @@ public class UpdateUserRequest {
   private String firstName;
   private String lastName;
   private LanguageType preferredLanguage;
-  private Date lastLogin;
 }

--- a/src/main/java/bio/overture/ego/model/entity/Application.java
+++ b/src/main/java/bio/overture/ego/model/entity/Application.java
@@ -16,9 +16,6 @@
 
 package bio.overture.ego.model.entity;
 
-import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
-import static com.google.common.collect.Sets.newHashSet;
-
 import bio.overture.ego.model.enums.ApplicationType;
 import bio.overture.ego.model.enums.JavaFields;
 import bio.overture.ego.model.enums.LombokFields;
@@ -26,26 +23,13 @@ import bio.overture.ego.model.enums.SqlFields;
 import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.model.enums.Tables;
 import bio.overture.ego.model.join.GroupApplication;
+import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
-import java.util.Set;
-import java.util.UUID;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -56,6 +40,23 @@ import lombok.experimental.Accessors;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static com.google.common.collect.Sets.newHashSet;
 
 @Entity
 @Table(name = Tables.APPLICATION)
@@ -135,9 +136,10 @@ public class Application implements Identifiable<UUID> {
 
   @JsonIgnore
   @Builder.Default
-  @ManyToMany(
-      mappedBy = JavaFields.APPLICATIONS,
+  @OneToMany(
+      mappedBy = JavaFields.APPLICATION,
+      cascade = CascadeType.ALL,
       fetch = FetchType.LAZY,
-      cascade = {CascadeType.MERGE, CascadeType.PERSIST})
-  private Set<User> users = newHashSet();
+      orphanRemoval = true)
+  private Set<UserApplication> userApplications = newHashSet();
 }

--- a/src/main/java/bio/overture/ego/model/entity/Application.java
+++ b/src/main/java/bio/overture/ego/model/entity/Application.java
@@ -16,6 +16,9 @@
 
 package bio.overture.ego.model.entity;
 
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static com.google.common.collect.Sets.newHashSet;
+
 import bio.overture.ego.model.enums.ApplicationType;
 import bio.overture.ego.model.enums.JavaFields;
 import bio.overture.ego.model.enums.LombokFields;
@@ -30,17 +33,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.experimental.Accessors;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-
+import java.util.Set;
+import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -52,11 +46,16 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-import java.util.Set;
-import java.util.UUID;
-
-import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
-import static com.google.common.collect.Sets.newHashSet;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 @Entity
 @Table(name = Tables.APPLICATION)

--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -16,6 +16,11 @@
 
 package bio.overture.ego.model.entity;
 
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static bio.overture.ego.service.UserService.resolveUsersPermissions;
+import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
+import static com.google.common.collect.Sets.newHashSet;
+
 import bio.overture.ego.model.enums.JavaFields;
 import bio.overture.ego.model.enums.LanguageType;
 import bio.overture.ego.model.enums.LombokFields;
@@ -31,17 +36,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -56,15 +54,16 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
-import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
-import static bio.overture.ego.service.UserService.resolveUsersPermissions;
-import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
-import static com.google.common.collect.Sets.newHashSet;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 @Slf4j
 @Entity
@@ -202,10 +201,7 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   }
 
   @PrePersist
-  private void onCreate(){
+  private void onCreate() {
     this.createdAt = new Date();
   }
-
-
-
 }

--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -16,11 +16,6 @@
 
 package bio.overture.ego.model.entity;
 
-import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
-import static bio.overture.ego.service.UserService.resolveUsersPermissions;
-import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
-import static com.google.common.collect.Sets.newHashSet;
-
 import bio.overture.ego.model.enums.JavaFields;
 import bio.overture.ego.model.enums.LanguageType;
 import bio.overture.ego.model.enums.LombokFields;
@@ -28,6 +23,7 @@ import bio.overture.ego.model.enums.SqlFields;
 import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.model.enums.Tables;
 import bio.overture.ego.model.enums.UserType;
+import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.model.join.UserGroup;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -35,24 +31,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.vladmihalcea.hibernate.type.basic.PostgreSQLEnumType;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -63,6 +41,27 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.AccessLevel.EGO_ENUM;
+import static bio.overture.ego.service.UserService.resolveUsersPermissions;
+import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
+import static com.google.common.collect.Sets.newHashSet;
 
 @Slf4j
 @Entity
@@ -181,15 +180,13 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   private Set<UserGroup> userGroups = newHashSet();
 
   @JsonIgnore
-  @ManyToMany(
-      fetch = FetchType.LAZY,
-      cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-  @JoinTable(
-      name = Tables.USER_APPLICATION,
-      joinColumns = {@JoinColumn(name = SqlFields.USERID_JOIN)},
-      inverseJoinColumns = {@JoinColumn(name = SqlFields.APPID_JOIN)})
   @Builder.Default
-  private Set<Application> applications = newHashSet();
+  @OneToMany(
+      mappedBy = JavaFields.USER,
+      cascade = CascadeType.ALL,
+      fetch = FetchType.LAZY,
+      orphanRemoval = true)
+  private Set<UserApplication> userApplications = newHashSet();
 
   // TODO: [rtisma] move getPermissions to UserService once DTO task is complete. JsonViews creates
   // a dependency for this method. For now, using a UserService static method.

--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -51,7 +51,10 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
 import java.util.List;
@@ -140,10 +143,12 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   @NotNull
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
   @Column(name = SqlFields.CREATEDAT)
+  @Temporal(value = TemporalType.TIMESTAMP)
   private Date createdAt;
 
   @JsonView({Views.JWTAccessToken.class, Views.REST.class})
   @Column(name = SqlFields.LASTLOGIN)
+  @Temporal(value = TemporalType.TIMESTAMP)
   private Date lastLogin;
 
   @Type(type = EGO_ENUM)
@@ -195,4 +200,12 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   public List<String> getPermissions() {
     return extractPermissionStrings(resolveUsersPermissions(this));
   }
+
+  @PrePersist
+  private void onCreate(){
+    this.createdAt = new Date();
+  }
+
+
+
 }

--- a/src/main/java/bio/overture/ego/model/enums/JavaFields.java
+++ b/src/main/java/bio/overture/ego/model/enums/JavaFields.java
@@ -16,15 +16,16 @@
 
 package bio.overture.ego.model.enums;
 
-import static lombok.AccessLevel.PRIVATE;
-
 import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @NoArgsConstructor(access = PRIVATE)
 public class JavaFields {
 
   public static final String ID = "id";
   public static final String NAME = "name";
+  public static final String TYPE = "type";
   public static final String EMAIL = "email";
   public static final String STATUS = "status";
   public static final String POLICY = "policy";

--- a/src/main/java/bio/overture/ego/model/enums/JavaFields.java
+++ b/src/main/java/bio/overture/ego/model/enums/JavaFields.java
@@ -61,4 +61,5 @@ public class JavaFields {
   public static final String USERGROUPS = "userGroups";
   public static final String APPLICATION_ID = "applicationId";
   public static final String GROUPAPPLICATIONS = "groupApplications";
+  public static final String USERAPPLICATIONS = "userApplications";
 }

--- a/src/main/java/bio/overture/ego/model/enums/JavaFields.java
+++ b/src/main/java/bio/overture/ego/model/enums/JavaFields.java
@@ -16,9 +16,9 @@
 
 package bio.overture.ego.model.enums;
 
-import lombok.NoArgsConstructor;
-
 import static lombok.AccessLevel.PRIVATE;
+
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
 public class JavaFields {

--- a/src/main/java/bio/overture/ego/model/join/UserApplication.java
+++ b/src/main/java/bio/overture/ego/model/join/UserApplication.java
@@ -1,0 +1,50 @@
+package bio.overture.ego.model.join;
+
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Identifiable;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.JavaFields;
+import bio.overture.ego.model.enums.LombokFields;
+import bio.overture.ego.model.enums.SqlFields;
+import bio.overture.ego.model.enums.Tables;
+import javax.persistence.CascadeType;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@Entity
+@Table(name = Tables.USER_APPLICATION)
+@Builder
+@EqualsAndHashCode(of = {LombokFields.id})
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = {JavaFields.USER, JavaFields.APPLICATION})
+public class UserApplication implements Identifiable<UserApplicationId> {
+
+  @EmbeddedId private UserApplicationId id;
+
+  @MapsId(value = JavaFields.USER_ID)
+  @JoinColumn(name = SqlFields.USERID_JOIN, nullable = false, updatable = false)
+  @ManyToOne(
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+      fetch = FetchType.LAZY)
+  private User user;
+
+  @MapsId(value = JavaFields.APPLICATION_ID)
+  @JoinColumn(name = SqlFields.APPID_JOIN, nullable = false, updatable = false)
+  @ManyToOne(
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+      fetch = FetchType.LAZY)
+  private Application application;
+}

--- a/src/main/java/bio/overture/ego/model/join/UserApplicationId.java
+++ b/src/main/java/bio/overture/ego/model/join/UserApplicationId.java
@@ -1,0 +1,25 @@
+package bio.overture.ego.model.join;
+
+import bio.overture.ego.model.enums.SqlFields;
+import java.io.Serializable;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserApplicationId implements Serializable {
+
+  @Column(name = SqlFields.USERID_JOIN)
+  private UUID userId;
+
+  @Column(name = SqlFields.APPID_JOIN)
+  private UUID applicationId;
+}

--- a/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
@@ -16,19 +16,6 @@
 
 package bio.overture.ego.repository.queryspecification;
 
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.join.GroupApplication;
-import bio.overture.ego.model.join.UserApplication;
-import bio.overture.ego.utils.QueryUtils;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
-
-import javax.persistence.criteria.Join;
-import java.util.UUID;
-
 import static bio.overture.ego.model.enums.JavaFields.CLIENTID;
 import static bio.overture.ego.model.enums.JavaFields.CLIENTSECRET;
 import static bio.overture.ego.model.enums.JavaFields.DESCRIPTION;
@@ -39,6 +26,18 @@ import static bio.overture.ego.model.enums.JavaFields.NAME;
 import static bio.overture.ego.model.enums.JavaFields.STATUS;
 import static bio.overture.ego.model.enums.JavaFields.USER;
 import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
+
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.join.GroupApplication;
+import bio.overture.ego.model.join.UserApplication;
+import bio.overture.ego.utils.QueryUtils;
+import java.util.UUID;
+import javax.persistence.criteria.Join;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
 
 public class ApplicationSpecification extends SpecificationBase<Application> {
   public static Specification<Application> containsText(@NonNull String text) {

--- a/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/ApplicationSpecification.java
@@ -16,6 +16,19 @@
 
 package bio.overture.ego.repository.queryspecification;
 
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.join.GroupApplication;
+import bio.overture.ego.model.join.UserApplication;
+import bio.overture.ego.utils.QueryUtils;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.Join;
+import java.util.UUID;
+
 import static bio.overture.ego.model.enums.JavaFields.CLIENTID;
 import static bio.overture.ego.model.enums.JavaFields.CLIENTSECRET;
 import static bio.overture.ego.model.enums.JavaFields.DESCRIPTION;
@@ -24,18 +37,8 @@ import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.ID;
 import static bio.overture.ego.model.enums.JavaFields.NAME;
 import static bio.overture.ego.model.enums.JavaFields.STATUS;
-import static bio.overture.ego.model.enums.JavaFields.USERS;
-
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.join.GroupApplication;
-import bio.overture.ego.utils.QueryUtils;
-import java.util.UUID;
-import javax.persistence.criteria.Join;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
+import static bio.overture.ego.model.enums.JavaFields.USER;
+import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 
 public class ApplicationSpecification extends SpecificationBase<Application> {
   public static Specification<Application> containsText(@NonNull String text) {
@@ -60,8 +63,9 @@ public class ApplicationSpecification extends SpecificationBase<Application> {
   public static Specification<Application> usedBy(@NonNull UUID userId) {
     return (root, query, builder) -> {
       query.distinct(true);
-      Join<Application, User> applicationUserJoin = root.join(USERS);
-      return builder.equal(applicationUserJoin.<Integer>get(ID), userId);
+      Join<Application, UserApplication> applicationJoin = root.join(USERAPPLICATIONS);
+      Join<UserApplication, User> userJoin = applicationJoin.join(USER);
+      return builder.equal(userJoin.<Integer>get(ID), userId);
     };
   }
 }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
@@ -16,20 +16,6 @@
 
 package bio.overture.ego.repository.queryspecification;
 
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.enums.JavaFields;
-import bio.overture.ego.model.join.UserApplication;
-import bio.overture.ego.model.join.UserGroup;
-import bio.overture.ego.utils.QueryUtils;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
-
-import javax.persistence.criteria.Join;
-import java.util.UUID;
-
 import static bio.overture.ego.model.enums.JavaFields.APPLICATION;
 import static bio.overture.ego.model.enums.JavaFields.EMAIL;
 import static bio.overture.ego.model.enums.JavaFields.FIRSTNAME;
@@ -40,6 +26,19 @@ import static bio.overture.ego.model.enums.JavaFields.NAME;
 import static bio.overture.ego.model.enums.JavaFields.STATUS;
 import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.USERGROUPS;
+
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.JavaFields;
+import bio.overture.ego.model.join.UserApplication;
+import bio.overture.ego.model.join.UserGroup;
+import bio.overture.ego.utils.QueryUtils;
+import java.util.UUID;
+import javax.persistence.criteria.Join;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
 
 public class UserSpecification extends SpecificationBase<User> {
 

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
@@ -16,7 +16,21 @@
 
 package bio.overture.ego.repository.queryspecification;
 
-import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.JavaFields;
+import bio.overture.ego.model.join.UserApplication;
+import bio.overture.ego.model.join.UserGroup;
+import bio.overture.ego.utils.QueryUtils;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.Join;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.JavaFields.APPLICATION;
 import static bio.overture.ego.model.enums.JavaFields.EMAIL;
 import static bio.overture.ego.model.enums.JavaFields.FIRSTNAME;
 import static bio.overture.ego.model.enums.JavaFields.GROUP;
@@ -24,19 +38,8 @@ import static bio.overture.ego.model.enums.JavaFields.ID;
 import static bio.overture.ego.model.enums.JavaFields.LASTNAME;
 import static bio.overture.ego.model.enums.JavaFields.NAME;
 import static bio.overture.ego.model.enums.JavaFields.STATUS;
+import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.USERGROUPS;
-
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.enums.JavaFields;
-import bio.overture.ego.model.join.UserGroup;
-import bio.overture.ego.utils.QueryUtils;
-import java.util.UUID;
-import javax.persistence.criteria.Join;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
 
 public class UserSpecification extends SpecificationBase<User> {
 
@@ -61,7 +64,8 @@ public class UserSpecification extends SpecificationBase<User> {
   public static Specification<User> ofApplication(@NonNull UUID appId) {
     return (root, query, builder) -> {
       query.distinct(true);
-      Join<User, Application> applicationJoin = root.join(APPLICATIONS);
+      Join<User, UserApplication> userJoin = root.join(USERAPPLICATIONS);
+      Join<UserApplication, Application> applicationJoin = userJoin.join(APPLICATION);
       return builder.equal(applicationJoin.<Integer>get(ID), appId);
     };
   }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/builder/AbstractSpecificationBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/builder/AbstractSpecificationBuilder.java
@@ -1,16 +1,15 @@
 package bio.overture.ego.repository.queryspecification.builder;
 
-import bio.overture.ego.model.enums.JavaFields;
-import lombok.NonNull;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
+import static bio.overture.ego.model.enums.JavaFields.NAME;
 
+import bio.overture.ego.model.enums.JavaFields;
+import java.util.Collection;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
-import java.util.Collection;
-
-import static bio.overture.ego.model.enums.JavaFields.NAME;
+import lombok.NonNull;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
 
 public abstract class AbstractSpecificationBuilder<T, ID> {
 
@@ -23,7 +22,7 @@ public abstract class AbstractSpecificationBuilder<T, ID> {
     };
   }
 
-  public Specification<T> listAll(){
+  public Specification<T> listAll() {
     return (fromUser, query, builder) -> {
       val root = setupFetchStrategy(fromUser);
       return builder.isNotNull(root.get(JavaFields.ID));

--- a/src/main/java/bio/overture/ego/repository/queryspecification/builder/ApplicationSpecificationBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/builder/ApplicationSpecificationBuilder.java
@@ -1,21 +1,23 @@
 package bio.overture.ego.repository.queryspecification.builder;
 
-import static bio.overture.ego.model.enums.JavaFields.CLIENTID;
-import static bio.overture.ego.model.enums.JavaFields.GROUP;
-import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
-import static bio.overture.ego.model.enums.JavaFields.USERS;
-import static javax.persistence.criteria.JoinType.LEFT;
-
 import bio.overture.ego.model.entity.Application;
-import java.util.UUID;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.val;
 import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.JavaFields.CLIENTID;
+import static bio.overture.ego.model.enums.JavaFields.GROUP;
+import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
+import static bio.overture.ego.model.enums.JavaFields.USER;
+import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
+import static javax.persistence.criteria.JoinType.LEFT;
 
 @Setter
 @Accessors(fluent = true, chain = true)
@@ -41,11 +43,12 @@ public class ApplicationSpecificationBuilder
   @Override
   protected Root<Application> setupFetchStrategy(Root<Application> root) {
     if (fetchGroups) {
-      val fromGroupApplications = root.fetch(GROUPAPPLICATIONS, LEFT);
-      fromGroupApplications.fetch(GROUP, LEFT);
+      root.fetch(GROUPAPPLICATIONS, LEFT)
+      .fetch(GROUP, LEFT);
     }
     if (fetchUsers) {
-      root.fetch(USERS, LEFT);
+      root.fetch(USERAPPLICATIONS, LEFT)
+          .fetch(USER, LEFT);
     }
     return root;
   }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/builder/ApplicationSpecificationBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/builder/ApplicationSpecificationBuilder.java
@@ -1,23 +1,22 @@
 package bio.overture.ego.repository.queryspecification.builder;
 
-import bio.overture.ego.model.entity.Application;
-import lombok.NonNull;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import lombok.val;
-import org.springframework.data.jpa.domain.Specification;
-
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import java.util.UUID;
-
 import static bio.overture.ego.model.enums.JavaFields.CLIENTID;
 import static bio.overture.ego.model.enums.JavaFields.GROUP;
 import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.USER;
 import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 import static javax.persistence.criteria.JoinType.LEFT;
+
+import bio.overture.ego.model.entity.Application;
+import java.util.UUID;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
 
 @Setter
 @Accessors(fluent = true, chain = true)
@@ -43,12 +42,10 @@ public class ApplicationSpecificationBuilder
   @Override
   protected Root<Application> setupFetchStrategy(Root<Application> root) {
     if (fetchGroups) {
-      root.fetch(GROUPAPPLICATIONS, LEFT)
-      .fetch(GROUP, LEFT);
+      root.fetch(GROUPAPPLICATIONS, LEFT).fetch(GROUP, LEFT);
     }
     if (fetchUsers) {
-      root.fetch(USERAPPLICATIONS, LEFT)
-          .fetch(USER, LEFT);
+      root.fetch(USERAPPLICATIONS, LEFT).fetch(USER, LEFT);
     }
     return root;
   }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/builder/UserSpecificationBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/builder/UserSpecificationBuilder.java
@@ -1,17 +1,18 @@
 package bio.overture.ego.repository.queryspecification.builder;
 
-import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
+import bio.overture.ego.model.entity.User;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import javax.persistence.criteria.Root;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.JavaFields.APPLICATION;
 import static bio.overture.ego.model.enums.JavaFields.GROUP;
+import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.USERGROUPS;
 import static bio.overture.ego.model.enums.JavaFields.USERPERMISSIONS;
 import static javax.persistence.criteria.JoinType.LEFT;
-
-import bio.overture.ego.model.entity.User;
-import java.util.UUID;
-import javax.persistence.criteria.Root;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-import lombok.val;
 
 @Setter
 @Accessors(fluent = true, chain = true)
@@ -24,11 +25,12 @@ public class UserSpecificationBuilder extends AbstractSpecificationBuilder<User,
   @Override
   protected Root<User> setupFetchStrategy(Root<User> root) {
     if (fetchApplications) {
-      root.fetch(APPLICATIONS, LEFT);
+      root.fetch(USERAPPLICATIONS, LEFT)
+          .fetch(APPLICATION, LEFT);
     }
     if (fetchUserGroups) {
-      val fromUserGroup = root.fetch(USERGROUPS, LEFT);
-      fromUserGroup.fetch(GROUP, LEFT);
+      root.fetch(USERGROUPS, LEFT)
+          .fetch(GROUP, LEFT);
     }
     if (fetchUserPermissions) {
       root.fetch(USERPERMISSIONS, LEFT);

--- a/src/main/java/bio/overture/ego/repository/queryspecification/builder/UserSpecificationBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/builder/UserSpecificationBuilder.java
@@ -1,18 +1,17 @@
 package bio.overture.ego.repository.queryspecification.builder;
 
-import bio.overture.ego.model.entity.User;
-import lombok.Setter;
-import lombok.experimental.Accessors;
-
-import javax.persistence.criteria.Root;
-import java.util.UUID;
-
 import static bio.overture.ego.model.enums.JavaFields.APPLICATION;
 import static bio.overture.ego.model.enums.JavaFields.GROUP;
 import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
 import static bio.overture.ego.model.enums.JavaFields.USERGROUPS;
 import static bio.overture.ego.model.enums.JavaFields.USERPERMISSIONS;
 import static javax.persistence.criteria.JoinType.LEFT;
+
+import bio.overture.ego.model.entity.User;
+import java.util.UUID;
+import javax.persistence.criteria.Root;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 @Setter
 @Accessors(fluent = true, chain = true)
@@ -25,12 +24,10 @@ public class UserSpecificationBuilder extends AbstractSpecificationBuilder<User,
   @Override
   protected Root<User> setupFetchStrategy(Root<User> root) {
     if (fetchApplications) {
-      root.fetch(USERAPPLICATIONS, LEFT)
-          .fetch(APPLICATION, LEFT);
+      root.fetch(USERAPPLICATIONS, LEFT).fetch(APPLICATION, LEFT);
     }
     if (fetchUserGroups) {
-      root.fetch(USERGROUPS, LEFT)
-          .fetch(GROUP, LEFT);
+      root.fetch(USERGROUPS, LEFT).fetch(GROUP, LEFT);
     }
     if (fetchUserPermissions) {
       root.fetch(USERPERMISSIONS, LEFT);

--- a/src/main/java/bio/overture/ego/service/AbstractBaseService.java
+++ b/src/main/java/bio/overture/ego/service/AbstractBaseService.java
@@ -1,9 +1,20 @@
 package bio.overture.ego.service;
 
+import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
+import static bio.overture.ego.utils.CollectionUtils.difference;
+import static bio.overture.ego.utils.Converters.convertToIds;
+import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
+import static bio.overture.ego.utils.EntityServices.getManyEntities;
+import static bio.overture.ego.utils.Joiners.COMMA;
+
 import bio.overture.ego.model.entity.Identifiable;
 import bio.overture.ego.repository.BaseRepository;
 import bio.overture.ego.repository.queryspecification.builder.AbstractSpecificationBuilder;
 import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -11,18 +22,6 @@ import lombok.val;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.utils.CollectionUtils.difference;
-import static bio.overture.ego.utils.Converters.convertToIds;
-import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
-import static bio.overture.ego.utils.EntityServices.getManyEntities;
-import static bio.overture.ego.utils.Joiners.COMMA;
 
 /**
  * Base implementation
@@ -65,16 +64,18 @@ public abstract class AbstractBaseService<T extends Identifiable<ID>, ID>
 
   @Override
   @SuppressWarnings("unchecked")
-  public Page<T> findAll(@NonNull AbstractSpecificationBuilder<T, ID> specificationBuilder, @NonNull Pageable pageable) {
+  public Page<T> findAll(
+      @NonNull AbstractSpecificationBuilder<T, ID> specificationBuilder,
+      @NonNull Pageable pageable) {
     return getRepository().findAll(specificationBuilder.listAll(), pageable);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public List<T> getMany(@NonNull Collection<ID> ids, @NonNull AbstractSpecificationBuilder<T, ID> specificationBuilder) {
-    val entities = (List<T>)getRepository().findAll(
-        specificationBuilder
-            .buildByIds(ids));
+  public List<T> getMany(
+      @NonNull Collection<ID> ids,
+      @NonNull AbstractSpecificationBuilder<T, ID> specificationBuilder) {
+    val entities = (List<T>) getRepository().findAll(specificationBuilder.buildByIds(ids));
     val requestedIds = ImmutableSet.copyOf(ids);
     val existingIds = convertToIds(entities);
     val nonExistingIds = difference(requestedIds, existingIds);
@@ -84,7 +85,6 @@ public abstract class AbstractBaseService<T extends Identifiable<ID>, ID>
         getEntityTypeName(),
         COMMA.join(nonExistingIds));
     return entities;
-
   }
 
   @Override

--- a/src/main/java/bio/overture/ego/service/ApplicationService.java
+++ b/src/main/java/bio/overture/ego/service/ApplicationService.java
@@ -16,6 +16,21 @@
 
 package bio.overture.ego.service;
 
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
+import static bio.overture.ego.model.exceptions.RequestValidationException.checkRequestValid;
+import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
+import static bio.overture.ego.token.app.AppTokenClaims.AUTHORIZED_GRANTS;
+import static bio.overture.ego.token.app.AppTokenClaims.ROLE;
+import static bio.overture.ego.token.app.AppTokenClaims.SCOPES;
+import static bio.overture.ego.utils.CollectionUtils.setOf;
+import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
+import static bio.overture.ego.utils.FieldUtils.onUpdateDetected;
+import static bio.overture.ego.utils.Splitters.COLON_SPLITTER;
+import static java.lang.String.format;
+import static org.mapstruct.factory.Mappers.getMapper;
+import static org.springframework.data.jpa.domain.Specification.where;
+
 import bio.overture.ego.model.dto.CreateApplicationRequest;
 import bio.overture.ego.model.dto.UpdateApplicationRequest;
 import bio.overture.ego.model.entity.Application;
@@ -29,6 +44,13 @@ import bio.overture.ego.repository.GroupRepository;
 import bio.overture.ego.repository.UserRepository;
 import bio.overture.ego.repository.queryspecification.ApplicationSpecification;
 import bio.overture.ego.repository.queryspecification.builder.ApplicationSpecificationBuilder;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -48,29 +70,6 @@ import org.springframework.security.oauth2.provider.ClientDetailsService;
 import org.springframework.security.oauth2.provider.ClientRegistrationException;
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static bio.overture.ego.model.enums.StatusType.APPROVED;
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.model.exceptions.RequestValidationException.checkRequestValid;
-import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
-import static bio.overture.ego.token.app.AppTokenClaims.AUTHORIZED_GRANTS;
-import static bio.overture.ego.token.app.AppTokenClaims.ROLE;
-import static bio.overture.ego.token.app.AppTokenClaims.SCOPES;
-import static bio.overture.ego.utils.CollectionUtils.setOf;
-import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
-import static bio.overture.ego.utils.FieldUtils.onUpdateDetected;
-import static bio.overture.ego.utils.Splitters.COLON_SPLITTER;
-import static java.lang.String.format;
-import static org.mapstruct.factory.Mappers.getMapper;
-import static org.springframework.data.jpa.domain.Specification.where;
 
 @Service
 @Slf4j

--- a/src/main/java/bio/overture/ego/service/BaseService.java
+++ b/src/main/java/bio/overture/ego/service/BaseService.java
@@ -1,19 +1,18 @@
 package bio.overture.ego.service;
 
+import static java.lang.String.format;
+
 import bio.overture.ego.model.exceptions.NotFoundException;
 import bio.overture.ego.repository.queryspecification.builder.AbstractSpecificationBuilder;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.val;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.lang.String.format;
 
 public interface BaseService<T, ID> {
 
@@ -36,9 +35,11 @@ public interface BaseService<T, ID> {
   void delete(ID id);
 
   Page<T> findAll(Specification specification, Pageable pageable);
+
   Page<T> findAll(AbstractSpecificationBuilder<T, ID> specificationBuilder, Pageable pageable);
 
   List<T> getMany(Collection<ID> ids, AbstractSpecificationBuilder<T, ID> specificationBuilder);
+
   Set<T> getMany(Collection<ID> ids);
 
   T getWithRelationships(ID id);

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -16,22 +16,6 @@
 
 package bio.overture.ego.service;
 
-import static bio.overture.ego.model.dto.Scope.effectiveScopes;
-import static bio.overture.ego.model.dto.Scope.explicitScopes;
-import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
-import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
-import static bio.overture.ego.model.enums.JavaFields.ID;
-import static bio.overture.ego.model.enums.JavaFields.SCOPES;
-import static bio.overture.ego.model.enums.JavaFields.USERS;
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.service.UserService.extractScopes;
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
-import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
-import static java.lang.String.format;
-import static java.util.UUID.fromString;
-import static javax.persistence.criteria.JoinType.LEFT;
-import static org.springframework.util.DigestUtils.md5Digest;
-
 import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.dto.TokenResponse;
 import bio.overture.ego.model.dto.TokenScopeResponse;
@@ -57,18 +41,6 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import java.security.InvalidKeyException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -81,6 +53,35 @@ import org.springframework.security.oauth2.common.exceptions.InvalidRequestExcep
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.stereotype.Service;
+
+import java.security.InvalidKeyException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static bio.overture.ego.model.dto.Scope.effectiveScopes;
+import static bio.overture.ego.model.dto.Scope.explicitScopes;
+import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
+import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
+import static bio.overture.ego.model.enums.JavaFields.ID;
+import static bio.overture.ego.model.enums.JavaFields.SCOPES;
+import static bio.overture.ego.model.enums.JavaFields.USERS;
+import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
+import static bio.overture.ego.service.UserService.extractScopes;
+import static bio.overture.ego.utils.CollectionUtils.mapToSet;
+import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
+import static java.lang.String.format;
+import static java.util.UUID.fromString;
+import static javax.persistence.criteria.JoinType.LEFT;
+import static org.springframework.util.DigestUtils.md5Digest;
 
 @Slf4j
 @Service
@@ -148,7 +149,7 @@ public class TokenService extends AbstractNamedService<Token, UUID> {
 
   @SneakyThrows
   public String generateUserToken(User u) {
-    Set<String> permissionNames = mapToSet(extractScopes(u), p -> p.toString());
+    Set<String> permissionNames = mapToSet(extractScopes(u), Scope::toString);
     return generateUserToken(u, permissionNames);
   }
 

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -16,6 +16,22 @@
 
 package bio.overture.ego.service;
 
+import static bio.overture.ego.model.dto.Scope.effectiveScopes;
+import static bio.overture.ego.model.dto.Scope.explicitScopes;
+import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
+import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
+import static bio.overture.ego.model.enums.JavaFields.ID;
+import static bio.overture.ego.model.enums.JavaFields.SCOPES;
+import static bio.overture.ego.model.enums.JavaFields.USERS;
+import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
+import static bio.overture.ego.service.UserService.extractScopes;
+import static bio.overture.ego.utils.CollectionUtils.mapToSet;
+import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
+import static java.lang.String.format;
+import static java.util.UUID.fromString;
+import static javax.persistence.criteria.JoinType.LEFT;
+import static org.springframework.util.DigestUtils.md5Digest;
+
 import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.dto.TokenResponse;
 import bio.overture.ego.model.dto.TokenScopeResponse;
@@ -40,6 +56,17 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.security.InvalidKeyException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -52,34 +79,6 @@ import org.springframework.security.oauth2.common.exceptions.InvalidRequestExcep
 import org.springframework.security.oauth2.common.exceptions.InvalidScopeException;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.stereotype.Service;
-
-import java.security.InvalidKeyException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static bio.overture.ego.model.dto.Scope.effectiveScopes;
-import static bio.overture.ego.model.dto.Scope.explicitScopes;
-import static bio.overture.ego.model.enums.ApplicationType.ADMIN;
-import static bio.overture.ego.model.enums.JavaFields.APPLICATIONS;
-import static bio.overture.ego.model.enums.JavaFields.ID;
-import static bio.overture.ego.model.enums.JavaFields.SCOPES;
-import static bio.overture.ego.model.enums.JavaFields.USERS;
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.service.UserService.extractScopes;
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
-import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
-import static java.lang.String.format;
-import static java.util.UUID.fromString;
-import static javax.persistence.criteria.JoinType.LEFT;
-import static org.springframework.util.DigestUtils.md5Digest;
 
 @Slf4j
 @Service
@@ -120,7 +119,6 @@ public class TokenService extends AbstractNamedService<Token, UUID> {
     this.tokenStoreService = tokenStoreService;
     this.policyService = policyService;
   }
-
 
   @Override
   public Token getWithRelationships(@NonNull UUID id) {

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -19,7 +19,6 @@ package bio.overture.ego.service;
 import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.dto.TokenResponse;
 import bio.overture.ego.model.dto.TokenScopeResponse;
-import bio.overture.ego.model.dto.UpdateUserRequest;
 import bio.overture.ego.model.dto.UserScopesResponse;
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Token;
@@ -58,7 +57,6 @@ import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -123,6 +121,7 @@ public class TokenService extends AbstractNamedService<Token, UUID> {
     this.policyService = policyService;
   }
 
+
   @Override
   public Token getWithRelationships(@NonNull UUID id) {
     val result =
@@ -132,18 +131,7 @@ public class TokenService extends AbstractNamedService<Token, UUID> {
   }
 
   public String generateUserToken(IDToken idToken) {
-    val userName = idToken.getEmail();
-    val user =
-        userService
-            .findByName(userName)
-            .orElseGet(
-                () -> {
-                  log.info("User not found, creating.");
-                  return userService.createFromIDToken(idToken);
-                });
-
-    val u = UpdateUserRequest.builder().lastLogin(new Date()).build();
-    userService.partialUpdate(user.getId(), u);
+    val user = userService.getUserByToken(idToken);
     return generateUserToken(user);
   }
 

--- a/src/main/java/bio/overture/ego/service/UserService.java
+++ b/src/main/java/bio/overture/ego/service/UserService.java
@@ -164,6 +164,18 @@ public class UserService extends AbstractNamedService<User, UUID> {
             .build());
   }
 
+  public User getUserByToken(@NonNull IDToken idToken){
+    val userName = idToken.getEmail();
+    val user = findByName(userName)
+        .orElseGet(
+            () -> {
+              log.info("User not found, creating.");
+              return createFromIDToken(idToken);
+            });
+    user.setLastLogin(new Date());
+    return user;
+  }
+
   @Override
   public User getWithRelationships(@NonNull UUID id) {
     return get(id, true, true, true);

--- a/src/main/java/bio/overture/ego/service/UserService.java
+++ b/src/main/java/bio/overture/ego/service/UserService.java
@@ -81,34 +81,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-
-import static bio.overture.ego.model.enums.UserType.ADMIN;
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.model.exceptions.RequestValidationException.checkRequestValid;
-import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
-import static bio.overture.ego.service.AbstractPermissionService.resolveFinalPermissions;
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
-import static bio.overture.ego.utils.Collectors.toImmutableSet;
-import static bio.overture.ego.utils.Converters.convertToUserGroup;
-import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
-import static bio.overture.ego.utils.FieldUtils.onUpdateDetected;
-import static bio.overture.ego.utils.Joiners.COMMA;
-import static java.lang.String.format;
-import static java.util.Collections.reverse;
-import static java.util.Comparator.comparing;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Stream.concat;
-import static org.springframework.data.jpa.domain.Specification.where;
-
 @Slf4j
 @Service
 @Transactional

--- a/src/main/java/bio/overture/ego/service/UserService.java
+++ b/src/main/java/bio/overture/ego/service/UserService.java
@@ -16,25 +16,6 @@
 
 package bio.overture.ego.service;
 
-import static bio.overture.ego.model.enums.UserType.ADMIN;
-import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
-import static bio.overture.ego.model.exceptions.RequestValidationException.checkRequestValid;
-import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
-import static bio.overture.ego.service.AbstractPermissionService.resolveFinalPermissions;
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
-import static bio.overture.ego.utils.Collectors.toImmutableSet;
-import static bio.overture.ego.utils.Converters.convertToUserGroup;
-import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
-import static bio.overture.ego.utils.FieldUtils.onUpdateDetected;
-import static bio.overture.ego.utils.Joiners.COMMA;
-import static java.lang.String.format;
-import static java.util.Collections.reverse;
-import static java.util.Comparator.comparing;
-import static java.util.Objects.isNull;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Stream.concat;
-import static org.springframework.data.jpa.domain.Specification.where;
-
 import bio.overture.ego.config.UserDefaultsConfig;
 import bio.overture.ego.event.token.TokenEventsPublisher;
 import bio.overture.ego.model.dto.CreateUserRequest;
@@ -46,7 +27,7 @@ import bio.overture.ego.model.entity.Group;
 import bio.overture.ego.model.entity.GroupPermission;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.entity.UserPermission;
-import bio.overture.ego.model.exceptions.NotFoundException;
+import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.model.join.UserGroup;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.GroupRepository;
@@ -56,14 +37,6 @@ import bio.overture.ego.repository.queryspecification.builder.UserSpecificationB
 import bio.overture.ego.token.IDToken;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import javax.transaction.Transactional;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -78,6 +51,36 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.UserType.ADMIN;
+import static bio.overture.ego.model.exceptions.NotFoundException.buildNotFoundException;
+import static bio.overture.ego.model.exceptions.NotFoundException.checkNotFound;
+import static bio.overture.ego.model.exceptions.RequestValidationException.checkRequestValid;
+import static bio.overture.ego.model.exceptions.UniqueViolationException.checkUnique;
+import static bio.overture.ego.service.AbstractPermissionService.resolveFinalPermissions;
+import static bio.overture.ego.utils.CollectionUtils.difference;
+import static bio.overture.ego.utils.CollectionUtils.intersection;
+import static bio.overture.ego.utils.CollectionUtils.mapToImmutableSet;
+import static bio.overture.ego.utils.CollectionUtils.mapToSet;
+import static bio.overture.ego.utils.Collectors.toImmutableSet;
+import static bio.overture.ego.utils.Converters.convertToIds;
+import static bio.overture.ego.utils.Converters.convertToUserApplication;
+import static bio.overture.ego.utils.Converters.convertToUserGroup;
+import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
+import static bio.overture.ego.utils.EntityServices.getManyEntities;
+import static bio.overture.ego.utils.FieldUtils.onUpdateDetected;
+import static bio.overture.ego.utils.Ids.checkDuplicates;
+import static bio.overture.ego.utils.Joiners.PRETTY_COMMA;
+import static java.util.Objects.isNull;
+import static org.springframework.data.jpa.domain.Specification.where;
 
 @Slf4j
 @Service
@@ -110,15 +113,6 @@ public class UserService extends AbstractNamedService<User, UUID> {
     this.applicationService = applicationService;
     this.userDefaultsConfig = userDefaultsConfig;
     this.tokenEventsPublisher = tokenEventsPublisher;
-  }
-
-  @Override
-  public void delete(@NonNull UUID id) {
-    val user = getWithRelationships(id);
-    disassociateAllGroupsFromUser(user);
-    disassociateAllApplicationsFromUser(user);
-    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(user));
-    super.delete(id);
   }
 
   public User create(@NonNull CreateUserRequest request) {
@@ -170,19 +164,17 @@ public class UserService extends AbstractNamedService<User, UUID> {
             .build());
   }
 
-  public User addUserToApps(@NonNull UUID id, @NonNull List<UUID> appIds) {
-    val user = getById(id);
-    val apps = applicationService.getMany(appIds);
-    associateUserWithApplications(user, apps);
-    // TODO: @rtisma test setting apps even if there were existing apps before does not delete the
-    // existing ones. Becuase the PERSIST and MERGE cascade applicationType is used, this should
-    // work correctly
-    return getRepository().save(user);
-  }
-
   @Override
   public User getWithRelationships(@NonNull UUID id) {
     return get(id, true, true, true);
+  }
+
+  public User getWithApplications(@NonNull UUID id){
+    return get(id, false, false, true);
+  }
+
+  public User getWithGroups(@NonNull UUID id){
+    return get(id, false, true, false);
   }
 
   /**
@@ -212,37 +204,147 @@ public class UserService extends AbstractNamedService<User, UUID> {
             pageable);
   }
 
-  public void disassociateGroupsFromUser(@NonNull UUID id, @NonNull Collection<UUID> groupIds) {
-    val userWithRelationships = get(id, false, true, false);
-    val userGroupsToDisassociate =
-        userWithRelationships.getUserGroups().stream()
-            .filter(x -> groupIds.contains(x.getId().getGroupId()))
-            .collect(toImmutableSet());
-    disassociateUserGroupsFromUser(userWithRelationships, userGroupsToDisassociate);
-    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(userWithRelationships));
+  @SuppressWarnings("Duplicates")
+  public User associateApplicationsWithUser(@NonNull UUID id, @NonNull Collection<UUID> applicationIds) {
+    // check duplicate applicationIds
+    checkDuplicates(Application.class, applicationIds);
+
+    // Get existing associated application ids with the user
+    val userWithUserApplications = getWithApplications(id);
+    val applications = mapToImmutableSet(userWithUserApplications.getUserApplications(), UserApplication::getApplication);
+    val existingAssociatedApplicationIds = convertToIds(applications);
+
+    // Check there are no application ids that are already associated with the user
+    val existingAlreadyAssociatedApplicationIds = intersection(existingAssociatedApplicationIds, applicationIds);
+    checkUnique(
+        existingAlreadyAssociatedApplicationIds.isEmpty(),
+        "The following %s ids are already associated with %s '%s': [%s]",
+        Application.class.getSimpleName(),
+        getEntityTypeName(),
+        id,
+        PRETTY_COMMA.join(existingAlreadyAssociatedApplicationIds));
+
+    // Get all unassociated application ids. If they do not exist, an error is thrown
+    val nonAssociatedApplicationIds = difference(applicationIds, existingAssociatedApplicationIds);
+    val nonAssociatedApplications = applicationService.getMany(nonAssociatedApplicationIds);
+
+    // Associate the existing applications with the user
+    nonAssociatedApplications.stream()
+        .map(a -> convertToUserApplication(userWithUserApplications, a))
+        .forEach(UserService::associateSelf);
+    return userWithUserApplications;
   }
 
+  @SuppressWarnings("Duplicates")
   public User associateGroupsWithUser(@NonNull UUID id, @NonNull Collection<UUID> groupIds) {
-    val user = getWithRelationships(id);
-    val groups = groupRepository.findAllByIdIn(groupIds);
-    groups.stream().map(g -> convertToUserGroup(user, g)).forEach(UserGroupService::associateSelf);
-    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(user));
-    return user;
+    // check duplicate groupIds
+    checkDuplicates(Group.class, groupIds);
+
+    // Get existing associated group ids with the user
+    val userWithUserGroups = getWithGroups(id);
+    val groups = mapToImmutableSet(userWithUserGroups.getUserGroups(), UserGroup::getGroup);
+    val existingAssociatedGroupIds = convertToIds(groups);
+
+    // Check there are no group ids that are already associated with the user
+    val existingAlreadyAssociatedGroupIds = intersection(existingAssociatedGroupIds, groupIds);
+    checkUnique(
+        existingAlreadyAssociatedGroupIds.isEmpty(),
+        "The following %s ids are already associated with %s '%s': [%s]",
+        Group.class.getSimpleName(),
+        getEntityTypeName(),
+        id,
+        PRETTY_COMMA.join(existingAlreadyAssociatedGroupIds));
+
+    // Get all unassociated group ids. If they do not exist, an error is thrown
+    val nonAssociatedGroupIds = difference(groupIds, existingAssociatedGroupIds);
+    val nonAssociatedGroups = getManyEntities(Group.class, groupRepository, nonAssociatedGroupIds);
+
+    // Associate the existing groups with the user
+    nonAssociatedGroups.stream()
+        .map(g -> convertToUserGroup(userWithUserGroups, g))
+        .forEach(UserGroupService::associateSelf);
+    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(userWithUserGroups));
+    return userWithUserGroups;
   }
 
-  // TODO @rtisma: add test for all entities to ensure they implement .equals() using only the id
-  // field
-  // TODO @rtisma: add test for checking user exists
-  // TODO @rtisma: add test for checking application exists for a user
-  public void deleteUserFromApps(@NonNull UUID id, @NonNull Collection<UUID> appIds) {
-    val user = getWithRelationships(id);
-    checkApplicationsExistForUser(user, appIds);
-    val appsToDisassociate =
-        user.getApplications().stream()
-            .filter(a -> appIds.contains(a.getId()))
+  @SuppressWarnings("Duplicates")
+  public void disassociateApplicationsFromUser(
+      @NonNull UUID id, @NonNull Collection<UUID> applicationIds) {
+    // check duplicate applicationIds
+    checkDuplicates(Application.class, applicationIds);
+
+    // Get existing associated child ids with the parent
+    val userWithApplications = getWithApplications(id);
+    val applications =
+        mapToImmutableSet(
+            userWithApplications.getUserApplications(), UserApplication::getApplication);
+    val existingAssociatedApplicationIds = convertToIds(applications);
+
+    // Get existing and non-existing non-associated application ids. Error out if there are existing
+    // and non-existing non-associated application ids
+    val nonAssociatedApplicationIds = difference(applicationIds, existingAssociatedApplicationIds);
+    if (!nonAssociatedApplicationIds.isEmpty()) {
+      applicationService.checkExistence(nonAssociatedApplicationIds);
+      throw buildNotFoundException(
+          "The following existing %s ids cannot be disassociated from %s '%s' "
+              + "because they are not associated with it",
+          Application.class.getSimpleName(), getEntityTypeName(), id);
+    }
+
+    // Since all application ids exist and are associated with the user, disassociate them from
+    // each other
+    val applicationIdsToDisassociate = ImmutableSet.copyOf(applicationIds);
+    val userApplicationsToDisassociate =
+        userWithApplications.getUserApplications().stream()
+            .filter(ga -> applicationIdsToDisassociate.contains(ga.getId().getApplicationId()))
             .collect(toImmutableSet());
-    disassociateUserFromApplications(user, appsToDisassociate);
-    getRepository().save(user);
+
+    disassociateUserApplicationsFromUser(userWithApplications, userApplicationsToDisassociate);
+  }
+
+  @SuppressWarnings("Duplicates")
+  public void disassociateGroupsFromUser(
+      @NonNull UUID id, @NonNull Collection<UUID> groupIds) {
+    // check duplicate groupIds
+    checkDuplicates(Group.class, groupIds);
+
+    // Get existing associated child ids with the parent
+    val userWithGroups = getWithGroups(id);
+    val groups =
+        mapToImmutableSet(
+            userWithGroups.getUserGroups(), UserGroup::getGroup);
+    val existingAssociatedGroupIds = convertToIds(groups);
+
+    // Get existing and non-existing non-associated group ids. Error out if there are existing
+    // and non-existing non-associated group ids
+    val nonAssociatedGroupIds = difference(groupIds, existingAssociatedGroupIds);
+    if (!nonAssociatedGroupIds.isEmpty()) {
+      checkEntityExistence(Group.class, groupRepository, nonAssociatedGroupIds);
+      throw buildNotFoundException(
+          "The following existing %s ids cannot be disassociated from %s '%s' "
+              + "because they are not associated with it",
+          Group.class.getSimpleName(), getEntityTypeName(), id);
+    }
+
+    // Since all group ids exist and are associated with the user, disassociate them from
+    // each other
+    val groupIdsToDisassociate = ImmutableSet.copyOf(groupIds);
+    val userGroupsToDisassociate =
+        userWithGroups.getUserGroups().stream()
+            .filter(ga -> groupIdsToDisassociate.contains(ga.getId().getGroupId()))
+            .collect(toImmutableSet());
+
+    disassociateUserGroupsFromUser(userWithGroups, userGroupsToDisassociate);
+    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(userWithGroups));
+  }
+
+  @Override
+  public void delete(@NonNull UUID id) {
+    val user = getWithRelationships(id);
+    disassociateAllGroupsFromUser(user);
+    disassociateAllApplicationsFromUser(user);
+    tokenEventsPublisher.requestTokenCleanupByUsers(ImmutableSet.of(user));
+    super.delete(id);
   }
 
   @SuppressWarnings("unchecked")
@@ -325,69 +427,29 @@ public class UserService extends AbstractNamedService<User, UUID> {
     return resolveFinalPermissions(userPermissions, groupPermissions);
   }
 
-  // TODO: [rtisma] this is the old implementation. Ensure there is a test for this, and if there
-  // isnt,
-  // create one, and ensure the Old and new refactored method are correct
-  @Deprecated
-  public static Set<AbstractPermission> getPermissionsListOld(User user) {
-    // Get user's individual permission (stream)
-    val userPermissions =
-        Optional.ofNullable(user.getUserPermissions()).orElse(new HashSet<>()).stream();
-
-    // Get permissions from the user's groups (stream)
-    val userGroupsPermissions =
-        Optional.ofNullable(user.getUserGroups()).orElse(new HashSet<>()).stream()
-            .map(UserGroup::getGroup)
-            .map(Group::getPermissions)
-            .flatMap(Collection::stream);
-
-    // Combine individual user permissions and the user's
-    // groups (if they have any) permissions
-    val combinedPermissions =
-        concat(userPermissions, userGroupsPermissions)
-            .collect(groupingBy(AbstractPermission::getPolicy));
-    // If we have no permissions at all return an empty list
-    if (combinedPermissions.values().size() == 0) {
-      return new HashSet<>();
-    }
-
-    // If we do have permissions ... sort the grouped permissions (by PolicyIdStringWithMaskName)
-    // on PolicyMask, extracting the first value of the sorted list into the final
-    // permissions list
-    HashSet<AbstractPermission> finalPermissionsList = new HashSet<>();
-
-    combinedPermissions.forEach(
-        (entity, permissions) -> {
-          permissions.sort(comparing(AbstractPermission::getAccessLevel));
-          reverse(permissions);
-          finalPermissionsList.add(permissions.get(0));
-        });
-    return finalPermissionsList;
-  }
-
   public static Set<Scope> extractScopes(@NonNull User user) {
     return mapToSet(resolveUsersPermissions(user), AbstractPermissionService::buildScope);
   }
 
-  public static void disassociateUserFromApplications(
-      @NonNull User user, @NonNull Collection<Application> applications) {
-    user.getApplications().removeAll(applications);
-    applications.forEach(x -> x.getUsers().remove(user));
+  public static void disassociateUserApplicationsFromUser(
+      @NonNull User g, @NonNull Collection<UserApplication> userApplications) {
+    userApplications.forEach(
+        ua -> {
+          ua.getApplication().getUserApplications().remove(ua);
+          ua.setApplication(null);
+          ua.setUser(null);
+        });
+    g.getUserApplications().removeAll(userApplications);
   }
 
-  public static void associateUserWithApplications(
-      @NonNull User user, @NonNull Collection<Application> apps) {
-    apps.forEach(a -> associateUserWithApplication(user, a));
+  public static void disassociateAllApplicationsFromUser(@NonNull User u) {
+    val userApplications = u.getUserApplications();
+    disassociateUserApplicationsFromUser(u, userApplications);
   }
 
-  public static void associateUserWithApplication(@NonNull User user, @NonNull Application app) {
-    user.getApplications().add(app);
-    app.getUsers().add(user);
-  }
-
-  public static void disassociateAllApplicationsFromUser(@NonNull User user) {
-    user.getApplications().forEach(x -> x.getUsers().remove(user));
-    user.getApplications().clear();
+  private static void associateSelf(@NonNull UserApplication ua) {
+    ua.getUser().getUserApplications().add(ua);
+    ua.getApplication().getUserApplications().add(ua);
   }
 
   public static void disassociateAllGroupsFromUser(@NonNull User userWithRelationships) {
@@ -403,20 +465,6 @@ public class UserService extends AbstractNamedService<User, UUID> {
           ug.setGroup(null);
         });
     user.getUserGroups().removeAll(userGroups);
-  }
-
-  public static void checkApplicationsExistForUser(
-      @NonNull User user, @NonNull Collection<UUID> appIds) {
-    val existingAppIds =
-        user.getApplications().stream().map(Application::getId).collect(toImmutableSet());
-    val nonExistentAppIds =
-        appIds.stream().filter(x -> !existingAppIds.contains(x)).collect(toImmutableSet());
-    if (!nonExistentAppIds.isEmpty()) {
-      throw new NotFoundException(
-          format(
-              "The following applications do not exist for user '%s': %s",
-              user.getId(), COMMA.join(nonExistentAppIds)));
-    }
   }
 
   @Mapper(

--- a/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
+++ b/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
@@ -21,14 +21,13 @@ import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.token.TokenClaims;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonView;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
+++ b/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
@@ -17,16 +17,18 @@
 package bio.overture.ego.token.user;
 
 import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.token.TokenClaims;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonView;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
@@ -48,7 +50,8 @@ public class UserTokenClaims extends TokenClaims {
   }
 
   public List<String> getAud() {
-    return this.context.getUserInfo().getApplications().stream()
+    return this.context.getUserInfo().getUserApplications().stream()
+        .map(UserApplication::getApplication)
         .map(Application::getName)
         .collect(Collectors.toList());
   }

--- a/src/main/java/bio/overture/ego/utils/Converters.java
+++ b/src/main/java/bio/overture/ego/utils/Converters.java
@@ -1,5 +1,12 @@
 package bio.overture.ego.utils;
 
+import static bio.overture.ego.utils.Collectors.toImmutableList;
+import static bio.overture.ego.utils.Collectors.toImmutableSet;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Objects.isNull;
+import static lombok.AccessLevel.PRIVATE;
+
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Group;
 import bio.overture.ego.model.entity.Identifiable;
@@ -10,22 +17,14 @@ import bio.overture.ego.model.join.UserApplication;
 import bio.overture.ego.model.join.UserApplicationId;
 import bio.overture.ego.model.join.UserGroup;
 import bio.overture.ego.model.join.UserGroupId;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.val;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-
-import static bio.overture.ego.utils.Collectors.toImmutableList;
-import static bio.overture.ego.utils.Collectors.toImmutableSet;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
-import static java.util.Objects.isNull;
-import static lombok.AccessLevel.PRIVATE;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.val;
 
 @NoArgsConstructor(access = PRIVATE)
 public class Converters {

--- a/src/main/java/bio/overture/ego/utils/Converters.java
+++ b/src/main/java/bio/overture/ego/utils/Converters.java
@@ -1,28 +1,31 @@
 package bio.overture.ego.utils;
 
-import static bio.overture.ego.utils.Collectors.toImmutableList;
-import static bio.overture.ego.utils.Collectors.toImmutableSet;
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
-import static java.util.Objects.isNull;
-import static lombok.AccessLevel.PRIVATE;
-
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Group;
 import bio.overture.ego.model.entity.Identifiable;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.join.GroupApplication;
 import bio.overture.ego.model.join.GroupApplicationId;
+import bio.overture.ego.model.join.UserApplication;
+import bio.overture.ego.model.join.UserApplicationId;
 import bio.overture.ego.model.join.UserGroup;
 import bio.overture.ego.model.join.UserGroupId;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.val;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.val;
+
+import static bio.overture.ego.utils.Collectors.toImmutableList;
+import static bio.overture.ego.utils.Collectors.toImmutableSet;
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Objects.isNull;
+import static lombok.AccessLevel.PRIVATE;
 
 @NoArgsConstructor(access = PRIVATE)
 public class Converters {
@@ -71,6 +74,11 @@ public class Converters {
     if (!isNull(nullableValue)) {
       consumer.accept(nullableValue);
     }
+  }
+
+  public static UserApplication convertToUserApplication(@NonNull User u, @NonNull Application a) {
+    val id = UserApplicationId.builder().applicationId(a.getId()).userId(u.getId()).build();
+    return UserApplication.builder().id(id).user(u).application(a).build();
   }
 
   public static UserGroup convertToUserGroup(@NonNull User u, @NonNull Group g) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
     enabled: false
   jackson:
     deserialization:
-      FAIL_ON_UNKNOWN_PROPERTIES: true
+      FAIL_ON_UNKNOWN_PROPERTIES: false
       FAIL_ON_NULL_FOR_PRIMITIVES: true
       FAIL_ON_NUMBERS_FOR_ENUMS: true
       FAIL_ON_READING_DUP_TREE_KEY: true

--- a/src/test/java/bio/overture/ego/controller/AbstractControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/AbstractControllerTest.java
@@ -1,5 +1,10 @@
 package bio.overture.ego.controller;
 
+import static bio.overture.ego.utils.Converters.convertToIds;
+import static bio.overture.ego.utils.Joiners.COMMA;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 import bio.overture.ego.model.dto.CreateApplicationRequest;
 import bio.overture.ego.model.dto.CreateUserRequest;
 import bio.overture.ego.model.dto.GroupRequest;
@@ -16,6 +21,8 @@ import bio.overture.ego.utils.web.ResponseOption;
 import bio.overture.ego.utils.web.StringResponseOption;
 import bio.overture.ego.utils.web.StringWebResource;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -25,14 +32,6 @@ import org.junit.Before;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
-
-import java.util.Collection;
-import java.util.UUID;
-
-import static bio.overture.ego.utils.Converters.convertToIds;
-import static bio.overture.ego.utils.Joiners.COMMA;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @Slf4j
 public abstract class AbstractControllerTest {
@@ -174,8 +173,7 @@ public abstract class AbstractControllerTest {
     return initStringRequest().endpoint("/users/%s/groups", userId).body(groupIds).postAnd();
   }
 
-  protected StringResponseOption addGroupsToUserPostRequestAnd(
-      User u, Collection<Group> groups) {
+  protected StringResponseOption addGroupsToUserPostRequestAnd(User u, Collection<Group> groups) {
     return addGroupsToUserPostRequestAnd(u.getId(), convertToIds(groups));
   }
 

--- a/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
@@ -17,28 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
-import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
-import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
-import static bio.overture.ego.model.enums.JavaFields.ID;
-import static bio.overture.ego.model.enums.JavaFields.NAME;
-import static bio.overture.ego.model.enums.JavaFields.STATUS;
-import static bio.overture.ego.model.enums.JavaFields.USERS;
-import static bio.overture.ego.model.enums.StatusType.APPROVED;
-import static bio.overture.ego.utils.CollectionUtils.repeatedCallsOf;
-import static bio.overture.ego.utils.EntityGenerator.generateNonExistentClientId;
-import static bio.overture.ego.utils.EntityGenerator.generateNonExistentId;
-import static bio.overture.ego.utils.EntityGenerator.generateNonExistentName;
-import static bio.overture.ego.utils.EntityGenerator.randomApplicationType;
-import static bio.overture.ego.utils.EntityGenerator.randomEnum;
-import static bio.overture.ego.utils.EntityGenerator.randomEnumExcluding;
-import static bio.overture.ego.utils.EntityGenerator.randomStatusType;
-import static bio.overture.ego.utils.EntityGenerator.randomStringNoSpaces;
-import static bio.overture.ego.utils.EntityGenerator.randomStringWithSpaces;
-import static bio.overture.ego.utils.Streams.stream;
-import static com.google.common.collect.Lists.newArrayList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.dto.CreateApplicationRequest;
 import bio.overture.ego.model.dto.UpdateApplicationRequest;
@@ -50,7 +28,6 @@ import bio.overture.ego.model.enums.StatusType;
 import bio.overture.ego.service.ApplicationService;
 import bio.overture.ego.utils.EntityGenerator;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -66,6 +43,30 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+
+import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
+import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
+import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
+import static bio.overture.ego.model.enums.JavaFields.ID;
+import static bio.overture.ego.model.enums.JavaFields.NAME;
+import static bio.overture.ego.model.enums.JavaFields.STATUS;
+import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.utils.CollectionUtils.repeatedCallsOf;
+import static bio.overture.ego.utils.EntityGenerator.generateNonExistentClientId;
+import static bio.overture.ego.utils.EntityGenerator.generateNonExistentId;
+import static bio.overture.ego.utils.EntityGenerator.generateNonExistentName;
+import static bio.overture.ego.utils.EntityGenerator.randomApplicationType;
+import static bio.overture.ego.utils.EntityGenerator.randomEnum;
+import static bio.overture.ego.utils.EntityGenerator.randomEnumExcluding;
+import static bio.overture.ego.utils.EntityGenerator.randomStatusType;
+import static bio.overture.ego.utils.EntityGenerator.randomStringNoSpaces;
+import static bio.overture.ego.utils.EntityGenerator.randomStringWithSpaces;
+import static bio.overture.ego.utils.Streams.stream;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -161,7 +162,7 @@ public class ApplicationControllerTest extends AbstractControllerTest {
     val application = applicationService.getByClientId("111111");
     getApplicationEntityGetRequestAnd(application)
         .assertEntityOfType(Application.class)
-        .isEqualToIgnoringGivenFields(application, GROUPAPPLICATIONS, USERS);
+        .isEqualToIgnoringGivenFields(application, GROUPAPPLICATIONS, USERAPPLICATIONS);
   }
 
   @Test
@@ -229,12 +230,12 @@ public class ApplicationControllerTest extends AbstractControllerTest {
 
     // Create the application using the request
     val app = createApplicationPostRequestAnd(createRequest).extractOneEntity(Application.class);
-    assertThat(app).isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERS);
+    assertThat(app).isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERAPPLICATIONS);
 
     // Get the application
     getApplicationEntityGetRequestAnd(app)
         .assertEntityOfType(Application.class)
-        .isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERS);
+        .isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERAPPLICATIONS);
   }
 
   @Test
@@ -367,7 +368,7 @@ public class ApplicationControllerTest extends AbstractControllerTest {
     // Assert app0 can be read
     getApplicationEntityGetRequestAnd(app0)
         .assertEntityOfType(Application.class)
-        .isEqualToIgnoringGivenFields(app0, GROUPAPPLICATIONS, USERS);
+        .isEqualToIgnoringGivenFields(app0, GROUPAPPLICATIONS, USERAPPLICATIONS);
   }
 
   @Test
@@ -430,7 +431,7 @@ public class ApplicationControllerTest extends AbstractControllerTest {
     partialUpdateApplicationPutRequestAnd(app0.getId(), updateRequest1).assertOk();
     val app0_after0 = getApplicationEntityGetRequestAnd(app0).extractOneEntity(Application.class);
     assertThat(app0_before0)
-        .isEqualToIgnoringGivenFields(app0_after0, ID, GROUPAPPLICATIONS, USERS, NAME);
+        .isEqualToIgnoringGivenFields(app0_after0, ID, GROUPAPPLICATIONS, USERAPPLICATIONS, NAME);
 
     // Update app0 with empty update request, and assert nothing changed
     val app0_before1 = getApplicationEntityGetRequestAnd(app0).extractOneEntity(Application.class);
@@ -448,7 +449,7 @@ public class ApplicationControllerTest extends AbstractControllerTest {
     partialUpdateApplicationPutRequestAnd(app0.getId(), updateRequest2).assertOk();
     val app0_after2 = getApplicationEntityGetRequestAnd(app0).extractOneEntity(Application.class);
     assertThat(app0_before2)
-        .isEqualToIgnoringGivenFields(app0_after2, ID, GROUPAPPLICATIONS, USERS, STATUS);
+        .isEqualToIgnoringGivenFields(app0_after2, ID, GROUPAPPLICATIONS, USERAPPLICATIONS, STATUS);
     assertThat(app0_before2.getStatus()).isNotEqualTo(app0_after2.getStatus());
     assertThat(app0_after2.getStatus()).isEqualTo(updateRequest2.getStatus());
   }

--- a/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/ApplicationControllerTest.java
@@ -17,35 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import bio.overture.ego.AuthorizationServiceMain;
-import bio.overture.ego.model.dto.CreateApplicationRequest;
-import bio.overture.ego.model.dto.UpdateApplicationRequest;
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.enums.ApplicationType;
-import bio.overture.ego.model.enums.StatusType;
-import bio.overture.ego.service.ApplicationService;
-import bio.overture.ego.utils.EntityGenerator;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.apache.commons.lang.NotImplementedException;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.List;
-
 import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
 import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
 import static bio.overture.ego.model.enums.JavaFields.GROUPAPPLICATIONS;
@@ -67,6 +38,34 @@ import static bio.overture.ego.utils.EntityGenerator.randomStringWithSpaces;
 import static bio.overture.ego.utils.Streams.stream;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import bio.overture.ego.AuthorizationServiceMain;
+import bio.overture.ego.model.dto.CreateApplicationRequest;
+import bio.overture.ego.model.dto.UpdateApplicationRequest;
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.ApplicationType;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.service.ApplicationService;
+import bio.overture.ego.utils.EntityGenerator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -230,7 +229,8 @@ public class ApplicationControllerTest extends AbstractControllerTest {
 
     // Create the application using the request
     val app = createApplicationPostRequestAnd(createRequest).extractOneEntity(Application.class);
-    assertThat(app).isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERAPPLICATIONS);
+    assertThat(app)
+        .isEqualToIgnoringGivenFields(createRequest, ID, GROUPAPPLICATIONS, USERAPPLICATIONS);
 
     // Get the application
     getApplicationEntityGetRequestAnd(app)

--- a/src/test/java/bio/overture/ego/controller/TokensOnUserAndPolicyDeletes.java
+++ b/src/test/java/bio/overture/ego/controller/TokensOnUserAndPolicyDeletes.java
@@ -17,6 +17,10 @@
 
 package bio.overture.ego.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.dto.PermissionRequest;
 import bio.overture.ego.model.entity.Policy;
@@ -38,10 +42,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @Slf4j
 @ActiveProfiles("test")

--- a/src/test/java/bio/overture/ego/controller/TokensOnUserAndPolicyDeletes.java
+++ b/src/test/java/bio/overture/ego/controller/TokensOnUserAndPolicyDeletes.java
@@ -17,10 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.dto.PermissionRequest;
 import bio.overture.ego.model.entity.Policy;
@@ -42,6 +38,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -92,7 +92,7 @@ public class TokensOnUserAndPolicyDeletes extends AbstractControllerTest {
 
     val checkTokenAfterDeleteResponse = checkToken(tokenToDelete);
     // Should be revoked
-    assertThat(checkTokenAfterDeleteResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(checkTokenAfterDeleteResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
     val checkTokenRemainedAfterDeleteResponse = checkToken(tokenToKeep);
     // Should be valid
@@ -121,7 +121,7 @@ public class TokensOnUserAndPolicyDeletes extends AbstractControllerTest {
 
     val checkTokenAfterDeleteResponse = checkToken(tokenToDelete);
     // Should be revoked
-    assertThat(checkTokenAfterDeleteResponse.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(checkTokenAfterDeleteResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
     val checkTokenRemainedAfterDeleteResponse = checkToken(tokenToKeep);
     // Should be valid

--- a/src/test/java/bio/overture/ego/controller/UserControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserControllerTest.java
@@ -17,43 +17,6 @@
 
 package bio.overture.ego.controller;
 
-import bio.overture.ego.AuthorizationServiceMain;
-import bio.overture.ego.model.dto.CreateUserRequest;
-import bio.overture.ego.model.dto.UpdateUserRequest;
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.Group;
-import bio.overture.ego.model.entity.Identifiable;
-import bio.overture.ego.model.entity.Policy;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.enums.LanguageType;
-import bio.overture.ego.model.enums.StatusType;
-import bio.overture.ego.model.enums.UserType;
-import bio.overture.ego.service.ApplicationService;
-import bio.overture.ego.service.GroupService;
-import bio.overture.ego.service.UserService;
-import bio.overture.ego.utils.EntityGenerator;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Sets;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.apache.commons.lang.NotImplementedException;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-
-import java.util.List;
-import java.util.UUID;
-
 import static bio.overture.ego.controller.resolver.PageableResolver.LIMIT;
 import static bio.overture.ego.controller.resolver.PageableResolver.OFFSET;
 import static bio.overture.ego.model.enums.JavaFields.CREATEDAT;
@@ -87,6 +50,42 @@ import static bio.overture.ego.utils.Streams.stream;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import bio.overture.ego.AuthorizationServiceMain;
+import bio.overture.ego.model.dto.CreateUserRequest;
+import bio.overture.ego.model.dto.UpdateUserRequest;
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.Group;
+import bio.overture.ego.model.entity.Identifiable;
+import bio.overture.ego.model.entity.Policy;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.LanguageType;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.model.enums.UserType;
+import bio.overture.ego.service.ApplicationService;
+import bio.overture.ego.service.GroupService;
+import bio.overture.ego.service.UserService;
+import bio.overture.ego.utils.EntityGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -143,9 +142,7 @@ public class UserControllerTest extends AbstractControllerTest {
     // Verify that the returned Users are the ones from the setup.
     Iterable<JsonNode> resultSetIterable = () -> responseJson.get("resultSet").iterator();
     val actualUserNames =
-        stream(resultSetIterable)
-            .map(j -> j.get("name").asText())
-            .collect(toImmutableList());
+        stream(resultSetIterable).map(j -> j.get("name").asText()).collect(toImmutableList());
     assertThat(actualUserNames)
         .contains("FirstUser@domain.com", "SecondUser@domain.com", "ThirdUser@domain.com");
   }
@@ -165,8 +162,8 @@ public class UserControllerTest extends AbstractControllerTest {
         .isEqualTo("FirstUser@domain.com");
   }
 
-	@Test
-	public void findUsers_FindAllQuery_Success(){
+  @Test
+  public void findUsers_FindAllQuery_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
 
@@ -174,84 +171,101 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Assert that you can page users that were created
     listUsersEndpointAnd()
-        .queryParam(LIMIT, numUsers )
+        .queryParam(LIMIT, numUsers)
         .queryParam(OFFSET, 0)
         .getAnd()
         .assertPageResultsOfType(User.class)
         .containsAll(data.getUsers());
-	}
+  }
 
   @Test
   @Ignore("low prority, but should be implemented")
-	public void findUsers_FindSomeQuery_Success(){
-		throw new NotImplementedException("need to implement the test 'findUsers_FindSomeQuery_Success'");
-	}
+  public void findUsers_FindSomeQuery_Success() {
+    throw new NotImplementedException(
+        "need to implement the test 'findUsers_FindSomeQuery_Success'");
+  }
 
-	@Test
-	public void createUser_NonExisting_Success(){
+  @Test
+  public void createUser_NonExisting_Success() {
     // Create unique name
     val name = generateNonExistentName(userService);
 
     // Create request
-    val r = CreateUserRequest.builder()
-        .email(name+"@gmail.com")
-        .status(randomEnum(StatusType.class))
-        .type(randomEnum(UserType.class))
-        .preferredLanguage(randomEnum(LanguageType.class))
-        .firstName(randomStringNoSpaces(10))
-        .lastName(randomStringNoSpaces(10))
-        .build();
+    val r =
+        CreateUserRequest.builder()
+            .email(name + "@gmail.com")
+            .status(randomEnum(StatusType.class))
+            .type(randomEnum(UserType.class))
+            .preferredLanguage(randomEnum(LanguageType.class))
+            .firstName(randomStringNoSpaces(10))
+            .lastName(randomStringNoSpaces(10))
+            .build();
 
     // Create the user
-    val user = createUserPostRequestAnd(r)
-        .extractOneEntity(User.class);
-    assertThat(user).isEqualToIgnoringGivenFields(r, ID, USERAPPLICATIONS, USERPERMISSIONS, USERGROUPS, TOKENS, NAME, CREATEDAT, LASTLOGIN);
-
+    val user = createUserPostRequestAnd(r).extractOneEntity(User.class);
+    assertThat(user)
+        .isEqualToIgnoringGivenFields(
+            r,
+            ID,
+            USERAPPLICATIONS,
+            USERPERMISSIONS,
+            USERGROUPS,
+            TOKENS,
+            NAME,
+            CREATEDAT,
+            LASTLOGIN);
 
     // Assert the user can be read and matches the request data
-    val r1 = getUserEntityGetRequestAnd(user)
-        .extractOneEntity(User.class);
-    assertThat(r1).isEqualToIgnoringGivenFields(r, ID, USERAPPLICATIONS, USERPERMISSIONS, USERGROUPS, TOKENS, NAME, CREATEDAT, LASTLOGIN);
+    val r1 = getUserEntityGetRequestAnd(user).extractOneEntity(User.class);
+    assertThat(r1)
+        .isEqualToIgnoringGivenFields(
+            r,
+            ID,
+            USERAPPLICATIONS,
+            USERPERMISSIONS,
+            USERGROUPS,
+            TOKENS,
+            NAME,
+            CREATEDAT,
+            LASTLOGIN);
     assertThat(r1).isEqualToIgnoringGivenFields(user);
-	}
+  }
 
-	@Test
-	public void createUser_EmailAlreadyExists_Conflict(){
+  @Test
+  public void createUser_EmailAlreadyExists_Conflict() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Get an existing name
-    val existingName = getUserEntityGetRequestAnd(user0)
-        .extractOneEntity(User.class)
-        .getName();
+    val existingName = getUserEntityGetRequestAnd(user0).extractOneEntity(User.class).getName();
 
     // Create a request with an existing name
-    val r = CreateUserRequest.builder()
-        .email(existingName)
-        .status(randomEnum(StatusType.class))
-        .type(randomEnum(UserType.class))
-        .preferredLanguage(randomEnum(LanguageType.class))
-        .firstName(randomStringNoSpaces(10))
-        .lastName(randomStringNoSpaces(10))
-        .build();
-
+    val r =
+        CreateUserRequest.builder()
+            .email(existingName)
+            .status(randomEnum(StatusType.class))
+            .type(randomEnum(UserType.class))
+            .preferredLanguage(randomEnum(LanguageType.class))
+            .firstName(randomStringNoSpaces(10))
+            .lastName(randomStringNoSpaces(10))
+            .build();
 
     // Create the user and assert a conflict
     createUserPostRequestAnd(r).assertConflict();
-	}
+  }
 
-	@Test
-	public void deleteUser_NonExisting_NotFound(){
+  @Test
+  public void deleteUser_NonExisting_NotFound() {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
     // Assert that you cannot delete a non-existent id
     deleteGroupDeleteRequestAnd(nonExistentId).assertNotFound();
-	}
+  }
 
-	@Test
-	public void deleteUserAndRelationshipsOnly_AlreadyExisting_Success(){
+  @Test
+  public void deleteUserAndRelationshipsOnly_AlreadyExisting_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -279,41 +293,47 @@ public class UserControllerTest extends AbstractControllerTest {
     getUserEntityGetRequestAnd(user0).assertNotFound();
 
     // Check applications exist
-    data.getApplications().forEach(application -> getApplicationEntityGetRequestAnd(application).assertOk());
+    data.getApplications()
+        .forEach(application -> getApplicationEntityGetRequestAnd(application).assertOk());
 
     // Check groups exist
     data.getGroups().forEach(group -> getGroupEntityGetRequestAnd(group).assertOk());
 
     // Check no users associated with applications
-    data.getApplications().forEach(a -> getUsersForApplicationGetRequestAnd(a).assertPageResultsOfType(User.class).isEmpty());
+    data.getApplications()
+        .forEach(
+            a ->
+                getUsersForApplicationGetRequestAnd(a)
+                    .assertPageResultsOfType(User.class)
+                    .isEmpty());
 
     // Check no users associated with groups
-    data.getGroups().forEach(g -> getUsersForGroupGetRequestAnd(g).assertPageResultsOfType(User.class).isEmpty());
-	}
+    data.getGroups()
+        .forEach(
+            g -> getUsersForGroupGetRequestAnd(g).assertPageResultsOfType(User.class).isEmpty());
+  }
 
-	@Test
-	public void getUser_ExistingUser_Success(){
+  @Test
+  public void getUser_ExistingUser_Success() {
     // Generate user
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert actual and expected user are the same
-    getUserEntityGetRequestAnd(user0.getId())
-        .assertEntityOfType(User.class)
-        .isEqualTo(user0);
-	}
+    getUserEntityGetRequestAnd(user0.getId()).assertEntityOfType(User.class).isEqualTo(user0);
+  }
 
-	@Test
-	public void getUser_NonExistentUser_NotFound(){
+  @Test
+  public void getUser_NonExistentUser_NotFound() {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
     // Assert that you cannot get a non-existent id
     getUserEntityGetRequestAnd(nonExistentId).assertNotFound();
-	}
+  }
 
-	@Test
-	public void UUIDValidation_MalformedUUID_BadRequest(){
+  @Test
+  public void UUIDValidation_MalformedUUID_BadRequest() {
     val data = generateUniqueTestUserData();
     val badUUID = "123sksk";
     val applicationIds = convertToIds(data.getApplications());
@@ -326,62 +346,82 @@ public class UserControllerTest extends AbstractControllerTest {
 
     initStringRequest().endpoint("/users/%s/applications", badUUID).getAnd().assertBadRequest();
     initStringRequest().endpoint("/users/%s/applications", badUUID).postAnd().assertBadRequest();
-    initStringRequest().endpoint("/users/%s/applications/%s", badUUID, COMMA.join(applicationIds)).deleteAnd().assertBadRequest();
+    initStringRequest()
+        .endpoint("/users/%s/applications/%s", badUUID, COMMA.join(applicationIds))
+        .deleteAnd()
+        .assertBadRequest();
 
     initStringRequest().endpoint("/users/%s/groups", badUUID).getAnd().assertBadRequest();
     initStringRequest().endpoint("/users/%s/groups", badUUID).postAnd().assertBadRequest();
-    initStringRequest().endpoint("/users/%s/groups/%s", badUUID, COMMA.join(groupIds)).deleteAnd().assertBadRequest();
+    initStringRequest()
+        .endpoint("/users/%s/groups/%s", badUUID, COMMA.join(groupIds))
+        .deleteAnd()
+        .assertBadRequest();
 
     initStringRequest().endpoint("/users/%s/permissions", badUUID).getAnd().assertBadRequest();
     initStringRequest().endpoint("/users/%s/permissions", badUUID).postAnd().assertBadRequest();
-    initStringRequest().endpoint("/users/%s/permissions/%s", badUUID, COMMA.join(randomPermIds)).deleteAnd().assertBadRequest();
-	}
+    initStringRequest()
+        .endpoint("/users/%s/permissions/%s", badUUID, COMMA.join(randomPermIds))
+        .deleteAnd()
+        .assertBadRequest();
+  }
 
-	@Test
-	public void updateUser_ExistingUser_Success(){
+  @Test
+  public void updateUser_ExistingUser_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // create update request 1
     val uniqueName = generateNonExistentName(userService);
-    val email = uniqueName+"@xyz.com";
-    val r1 = UpdateUserRequest.builder()
-        .firstName("aNewFirstName")
-        .email(email)
-        .build();
+    val email = uniqueName + "@xyz.com";
+    val r1 = UpdateUserRequest.builder().firstName("aNewFirstName").email(email).build();
 
     // Update user
     partialUpdateUserPutRequestAnd(user0.getId(), r1).assertOk();
 
     // Assert update was correct
-    val actualUser1 = getUserEntityGetRequestAnd(user0)
-        .extractOneEntity(User.class);
-    assertThat(actualUser1).isEqualToIgnoringGivenFields(r1, TYPE, STATUS, NAME, LASTNAME, PREFERREDLANGUAGE,ID, CREATEDAT, LASTLOGIN, USERPERMISSIONS, USERAPPLICATIONS, USERGROUPS, TOKENS);
+    val actualUser1 = getUserEntityGetRequestAnd(user0).extractOneEntity(User.class);
+    assertThat(actualUser1)
+        .isEqualToIgnoringGivenFields(
+            r1,
+            TYPE,
+            STATUS,
+            NAME,
+            LASTNAME,
+            PREFERREDLANGUAGE,
+            ID,
+            CREATEDAT,
+            LASTLOGIN,
+            USERPERMISSIONS,
+            USERAPPLICATIONS,
+            USERGROUPS,
+            TOKENS);
     assertThat(actualUser1.getFirstName()).isEqualTo(r1.getFirstName());
     assertThat(actualUser1.getEmail()).isEqualTo(r1.getEmail());
     assertThat(actualUser1.getName()).isEqualTo(r1.getEmail());
 
     // create update request 2
-    val r2 = UpdateUserRequest.builder()
-        .status(randomEnumExcluding(StatusType.class, user0.getStatus()))
-        .type(randomEnumExcluding(UserType.class, user0.getType()))
-        .preferredLanguage(randomEnumExcluding(LanguageType.class, user0.getPreferredLanguage()))
-        .build();
+    val r2 =
+        UpdateUserRequest.builder()
+            .status(randomEnumExcluding(StatusType.class, user0.getStatus()))
+            .type(randomEnumExcluding(UserType.class, user0.getType()))
+            .preferredLanguage(
+                randomEnumExcluding(LanguageType.class, user0.getPreferredLanguage()))
+            .build();
 
     // Update user
     partialUpdateUserPutRequestAnd(user0.getId(), r2).assertOk();
 
     // Assert update was correct
-    val actualUser2 = getUserEntityGetRequestAnd(user0)
-        .extractOneEntity(User.class);
+    val actualUser2 = getUserEntityGetRequestAnd(user0).extractOneEntity(User.class);
     assertThat(actualUser2.getStatus()).isEqualTo(r2.getStatus());
     assertThat(actualUser2.getType()).isEqualTo(r2.getType());
     assertThat(actualUser2.getPreferredLanguage()).isEqualTo(r2.getPreferredLanguage());
-	}
+  }
 
-	@Test
-	public void updateUser_NonExistentUser_NotFound(){
+  @Test
+  public void updateUser_NonExistentUser_NotFound() {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
@@ -389,10 +429,10 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Assert that you cannot get a non-existent id
     partialUpdateUserPutRequestAnd(nonExistentId, dummyUpdateUserRequest).assertNotFound();
-	}
+  }
 
-	@Test
-	public void updateUser_EmailAlreadyExists_Conflict(){
+  @Test
+  public void updateUser_EmailAlreadyExists_Conflict() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -403,17 +443,19 @@ public class UserControllerTest extends AbstractControllerTest {
     assertThat(user1.getName()).isEqualTo(user1.getEmail());
 
     // Create update request with same email
-    val r1 = UpdateUserRequest.builder()
-        .email(user1.getName())
-        .status(randomEnumExcluding(StatusType.class, user0.getStatus()))
-        .build();
+    val r1 =
+        UpdateUserRequest.builder()
+            .email(user1.getName())
+            .status(randomEnumExcluding(StatusType.class, user0.getStatus()))
+            .build();
 
-    // Assert that a CONFLICT error occurs when trying to update a user with a name that already exists
+    // Assert that a CONFLICT error occurs when trying to update a user with a name that already
+    // exists
     partialUpdateUserPutRequestAnd(user0.getId(), r1).assertConflict();
-	}
+  }
 
-	@Test
-	public void statusValidation_MalformedStatus_BadRequest(){
+  @Test
+  public void statusValidation_MalformedStatus_BadRequest() {
     val invalidStatus = "something123";
     val match = stream(StatusType.values()).anyMatch(x -> x.toString().equals(invalidStatus));
     assertThat(match).isFalse();
@@ -422,34 +464,28 @@ public class UserControllerTest extends AbstractControllerTest {
     val user = data.getUsers().get(0);
 
     // Assert createUsers
-    val templateR1 = CreateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .type(USER)
-        .preferredLanguage(ENGLISH)
-        .build();
-    val r1 = ((ObjectNode)MAPPER.valueToTree(templateR1)).put(STATUS, invalidStatus);
-    initStringRequest()
-        .endpoint("/users")
-        .body(r1)
-        .postAnd()
-        .assertBadRequest();
+    val templateR1 =
+        CreateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .type(USER)
+            .preferredLanguage(ENGLISH)
+            .build();
+    val r1 = ((ObjectNode) MAPPER.valueToTree(templateR1)).put(STATUS, invalidStatus);
+    initStringRequest().endpoint("/users").body(r1).postAnd().assertBadRequest();
 
     // Assert updateUser
-    val templateR2 = UpdateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .type(USER)
-        .preferredLanguage(ENGLISH)
-        .build();
-    val r2 = ((ObjectNode)MAPPER.valueToTree(templateR2)).put(STATUS, invalidStatus);
-    initStringRequest()
-        .endpoint("/users/%s", user.getId())
-        .body(r2)
-        .putAnd()
-        .assertBadRequest();
-	}
+    val templateR2 =
+        UpdateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .type(USER)
+            .preferredLanguage(ENGLISH)
+            .build();
+    val r2 = ((ObjectNode) MAPPER.valueToTree(templateR2)).put(STATUS, invalidStatus);
+    initStringRequest().endpoint("/users/%s", user.getId()).body(r2).putAnd().assertBadRequest();
+  }
 
-	@Test
-	public void typeValidation_MalformedType_BadRequest(){
+  @Test
+  public void typeValidation_MalformedType_BadRequest() {
     val invalidType = "something123";
     val match = stream(UserType.values()).anyMatch(x -> x.toString().equals(invalidType));
     assertThat(match).isFalse();
@@ -458,34 +494,28 @@ public class UserControllerTest extends AbstractControllerTest {
     val user = data.getUsers().get(0);
 
     // Assert createUsers
-    val templateR1 = CreateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .status(APPROVED)
-        .preferredLanguage(ENGLISH)
-        .build();
-    val r1 = ((ObjectNode)MAPPER.valueToTree(templateR1)).put(TYPE, invalidType);
-    initStringRequest()
-        .endpoint("/users")
-        .body(r1)
-        .postAnd()
-        .assertBadRequest();
+    val templateR1 =
+        CreateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .status(APPROVED)
+            .preferredLanguage(ENGLISH)
+            .build();
+    val r1 = ((ObjectNode) MAPPER.valueToTree(templateR1)).put(TYPE, invalidType);
+    initStringRequest().endpoint("/users").body(r1).postAnd().assertBadRequest();
 
     // Assert updateUser
-    val templateR2 = UpdateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .status(DISABLED)
-        .preferredLanguage(ENGLISH)
-        .build();
-    val r2 = ((ObjectNode)MAPPER.valueToTree(templateR2)).put(TYPE, invalidType);
-    initStringRequest()
-        .endpoint("/users/%s", user.getId())
-        .body(r2)
-        .putAnd()
-        .assertBadRequest();
-	}
+    val templateR2 =
+        UpdateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .status(DISABLED)
+            .preferredLanguage(ENGLISH)
+            .build();
+    val r2 = ((ObjectNode) MAPPER.valueToTree(templateR2)).put(TYPE, invalidType);
+    initStringRequest().endpoint("/users/%s", user.getId()).body(r2).putAnd().assertBadRequest();
+  }
 
-	@Test
-	public void preferredLanguageValidation_MalformedPreferredLanguage_BadRequest(){
+  @Test
+  public void preferredLanguageValidation_MalformedPreferredLanguage_BadRequest() {
     val invalidLanguage = "something123";
     val match = stream(LanguageType.values()).anyMatch(x -> x.toString().equals(invalidLanguage));
     assertThat(match).isFalse();
@@ -494,34 +524,28 @@ public class UserControllerTest extends AbstractControllerTest {
     val user = data.getUsers().get(0);
 
     // Assert createUsers
-    val templateR1 = CreateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .status(APPROVED)
-        .type(USER)
-        .build();
-    val r1 = ((ObjectNode)MAPPER.valueToTree(templateR1)).put(PREFERREDLANGUAGE, invalidLanguage);
-    initStringRequest()
-        .endpoint("/users")
-        .body(r1)
-        .postAnd()
-        .assertBadRequest();
+    val templateR1 =
+        CreateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .status(APPROVED)
+            .type(USER)
+            .build();
+    val r1 = ((ObjectNode) MAPPER.valueToTree(templateR1)).put(PREFERREDLANGUAGE, invalidLanguage);
+    initStringRequest().endpoint("/users").body(r1).postAnd().assertBadRequest();
 
     // Assert updateUser
-    val templateR2 = UpdateUserRequest.builder()
-        .email(generateNonExistentName(userService)+"@xyz.com")
-        .status(DISABLED)
-        .type(USER)
-        .build();
-    val r2 = ((ObjectNode)MAPPER.valueToTree(templateR2)).put(PREFERREDLANGUAGE, invalidLanguage);
-    initStringRequest()
-        .endpoint("/users/%s", user.getId())
-        .body(r2)
-        .putAnd()
-        .assertBadRequest();
-	}
+    val templateR2 =
+        UpdateUserRequest.builder()
+            .email(generateNonExistentName(userService) + "@xyz.com")
+            .status(DISABLED)
+            .type(USER)
+            .build();
+    val r2 = ((ObjectNode) MAPPER.valueToTree(templateR2)).put(PREFERREDLANGUAGE, invalidLanguage);
+    initStringRequest().endpoint("/users/%s", user.getId()).body(r2).putAnd().assertBadRequest();
+  }
 
-	@Test
-	public void getApplicationsFromUser_FindAllQuery_Success(){
+  @Test
+  public void getApplicationsFromUser_FindAllQuery_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -533,25 +557,25 @@ public class UserControllerTest extends AbstractControllerTest {
     getApplicationsForUserGetRequestAnd(user0)
         .assertPageResultsOfType(Application.class)
         .containsExactlyInAnyOrderElementsOf(data.getApplications());
-	}
+  }
 
-	@Test
-	public void getApplicationsFromUser_NonExistentUser_NotFound(){
+  @Test
+  public void getApplicationsFromUser_NonExistentUser_NotFound() {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
     // Assert that getting the applications for a non-existent user id results in a NOT_FOUND error
     getApplicationsForUserGetRequestAnd(nonExistentId).assertNotFound();
-	}
+  }
 
-	@Test
+  @Test
   @Ignore("low priority, but should be implemented")
-	public void getApplicationsFromUser_FindSomeQuery_Success(){
+  public void getApplicationsFromUser_FindSomeQuery_Success() {
     throw new NotImplementedException("need to implement");
-	}
+  }
 
-	@Test
-	public void addApplicationsToUser_NonExistentUser_NotFound(){
+  @Test
+  public void addApplicationsToUser_NonExistentUser_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val existingApplicationIds = convertToIds(data.getApplications());
@@ -561,10 +585,10 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Assert NOT_FOUND thrown when adding existing applications to a non-existing user
     addApplicationsToUserPostRequestAnd(nonExistentId, existingApplicationIds).assertNotFound();
-	}
+  }
 
-	@Test
-	public void addApplicationsToUser_AllExistingUnassociatedApplications_Success(){
+  @Test
+  public void addApplicationsToUser_AllExistingUnassociatedApplications_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -573,28 +597,34 @@ public class UserControllerTest extends AbstractControllerTest {
     getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
 
     // Add applications to user and assert the response is equal to the user
-    addApplicationsToUserPostRequestAnd(user0, data.getApplications()).assertEntityOfType(User.class).isEqualToIgnoringGivenFields(user0, USERPERMISSIONS, TOKENS, USERGROUPS, USERAPPLICATIONS);
+    addApplicationsToUserPostRequestAnd(user0, data.getApplications())
+        .assertEntityOfType(User.class)
+        .isEqualToIgnoringGivenFields(user0, USERPERMISSIONS, TOKENS, USERGROUPS, USERAPPLICATIONS);
 
     // Assert the user has all the applications
-    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).containsExactlyInAnyOrderElementsOf(data.getApplications());
-	}
+    getApplicationsForUserGetRequestAnd(user0)
+        .assertPageResultsOfType(Application.class)
+        .containsExactlyInAnyOrderElementsOf(data.getApplications());
+  }
 
-	@Test
-	public void addApplicationsToUser_SomeExistingApplicationsButAllUnassociated_NotFound(){
+  @Test
+  public void addApplicationsToUser_SomeExistingApplicationsButAllUnassociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert NOT_FOUND thrown when adding non-existing applications to an existing user
     val someExistingApplicationIds = mapToSet(data.getApplications(), Identifiable::getId);
-    val nonExistingApplicationIds = repeatedCallsOf(() -> generateNonExistentId(applicationService), 10).stream().collect(toImmutableSet());
+    val nonExistingApplicationIds =
+        repeatedCallsOf(() -> generateNonExistentId(applicationService), 10).stream()
+            .collect(toImmutableSet());
     someExistingApplicationIds.addAll(nonExistingApplicationIds);
 
     addApplicationsToUserPostRequestAnd(user0.getId(), someExistingApplicationIds).assertNotFound();
-	}
+  }
 
-	@Test
-	public void addApplicationsToUser_AllExistingApplicationsButSomeAlreadyAssociated_Conflict(){
+  @Test
+  public void addApplicationsToUser_AllExistingApplicationsButSomeAlreadyAssociated_Conflict() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -605,25 +635,28 @@ public class UserControllerTest extends AbstractControllerTest {
     getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
 
     // Add app00 to user and assert the response is equal to the user
-    addApplicationsToUserPostRequestAnd(user0, newArrayList(app0)).assertEntityOfType(User.class).isEqualToIgnoringGivenFields(user0, USERPERMISSIONS, TOKENS, USERGROUPS, USERAPPLICATIONS);
+    addApplicationsToUserPostRequestAnd(user0, newArrayList(app0))
+        .assertEntityOfType(User.class)
+        .isEqualToIgnoringGivenFields(user0, USERPERMISSIONS, TOKENS, USERGROUPS, USERAPPLICATIONS);
 
     // Assert the user has app0
-    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).containsExactlyInAnyOrder(app0);
+    getApplicationsForUserGetRequestAnd(user0)
+        .assertPageResultsOfType(Application.class)
+        .containsExactlyInAnyOrder(app0);
 
-    // Add app0 and app1 to user and assert a CONFLICT error is returned since app0 was already associated
+    // Add app0 and app1 to user and assert a CONFLICT error is returned since app0 was already
+    // associated
     addApplicationsToUserPostRequestAnd(user0, newArrayList(app0, app1)).assertConflict();
-	}
+  }
 
-	@Test
-	public void removeApplicationsFromUser_AllExistingAssociatedApplications_Success(){
+  @Test
+  public void removeApplicationsFromUser_AllExistingAssociatedApplications_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert the user has no applications
-    getApplicationsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Application.class)
-        .isEmpty();
+    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
 
     // Add apps to user and assert user is returned
     addApplicationsToUserPostRequestAnd(user0, data.getApplications())
@@ -636,16 +669,14 @@ public class UserControllerTest extends AbstractControllerTest {
         .containsExactlyInAnyOrderElementsOf(data.getApplications());
 
     // Delete applications from user
-    deleteApplicationsFromUserDeleteRequestAnd(user0,data.getApplications()).assertOk();
+    deleteApplicationsFromUserDeleteRequestAnd(user0, data.getApplications()).assertOk();
 
     // Assert the user has no applications
-    getApplicationsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Application.class)
-        .isEmpty();
-	}
+    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
+  }
 
-	@Test
-	public void removeApplicationsFromUser_AllExistingApplicationsButSomeNotAssociated_NotFound(){
+  @Test
+  public void removeApplicationsFromUser_AllExistingApplicationsButSomeNotAssociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -653,9 +684,7 @@ public class UserControllerTest extends AbstractControllerTest {
     val app1 = data.getApplications().get(1);
 
     // Assert the user has no applications
-    getApplicationsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Application.class)
-        .isEmpty();
+    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
 
     // Add apps to user and assert user is returned
     addApplicationsToUserPostRequestAnd(user0, newArrayList(app0))
@@ -669,18 +698,16 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Delete applications from user
     deleteApplicationsFromUserDeleteRequestAnd(user0, newArrayList(app0, app1)).assertNotFound();
-	}
+  }
 
-	@Test
-	public void removeApplicationsFromUser_SomeNonExistingApplicationsButAllAssociated_NotFound(){
+  @Test
+  public void removeApplicationsFromUser_SomeNonExistingApplicationsButAllAssociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert the user has no applications
-    getApplicationsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Application.class)
-        .isEmpty();
+    getApplicationsForUserGetRequestAnd(user0).assertPageResultsOfType(Application.class).isEmpty();
 
     // Add all apps to user
     addApplicationsToUserPostRequestAnd(user0, data.getApplications())
@@ -701,12 +728,14 @@ public class UserControllerTest extends AbstractControllerTest {
     someExistingApplicationsIds.addAll(convertToIds(data.getApplications()));
     someExistingApplicationsIds.add(nonExistingApplicationId);
 
-    // Delete applications from user and assert a NOT_FOUND error was returned due to the non-existing application id
-    deleteApplicationsFromUserDeleteRequestAnd(user0.getId(), someExistingApplicationsIds).assertNotFound();
-	}
+    // Delete applications from user and assert a NOT_FOUND error was returned due to the
+    // non-existing application id
+    deleteApplicationsFromUserDeleteRequestAnd(user0.getId(), someExistingApplicationsIds)
+        .assertNotFound();
+  }
 
-	@Test
-	public void removeApplicationsFromUser_NonExistentUser_NotFound(){
+  @Test
+  public void removeApplicationsFromUser_NonExistentUser_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val existingApplicationIds = convertToIds(data.getApplications());
@@ -715,19 +744,18 @@ public class UserControllerTest extends AbstractControllerTest {
     val nonExistentId = generateNonExistentId(userService);
 
     // Assert NOT_FOUND thrown when deleting applications to a non-existing user
-    deleteApplicationsFromUserDeleteRequestAnd(nonExistentId, existingApplicationIds).assertNotFound();
-	}
+    deleteApplicationsFromUserDeleteRequestAnd(nonExistentId, existingApplicationIds)
+        .assertNotFound();
+  }
 
-	@Test
-	public void getGroupsFromUser_FindAllQuery_Success(){
+  @Test
+  public void getGroupsFromUser_FindAllQuery_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert no groups are associated with the user
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
 
     // Add groups to the user
     addGroupsToUserPostRequestAnd(user0, data.getGroups()).assertOk();
@@ -738,43 +766,43 @@ public class UserControllerTest extends AbstractControllerTest {
         .containsExactlyInAnyOrderElementsOf(data.getGroups());
   }
 
-	@Test
-	public void getGroupsFromUser_NonExistentUser_NotFound(){
+  @Test
+  public void getGroupsFromUser_NonExistentUser_NotFound() {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
     // Assert that a NOT_FOUND error is thrown when attempting to all groups for a non-existent user
     getGroupsForUserGetRequestAnd(nonExistentId).assertNotFound();
-	}
+  }
 
-	@Test
+  @Test
   @Ignore("low priority, but should be implemented")
-	public void getGroupsFromUser_FindSomeQuery_Success(){
-		throw new NotImplementedException("need to implement the test 'getGroupsFromUser_FindSomeQuery_Success'");
-	}
+  public void getGroupsFromUser_FindSomeQuery_Success() {
+    throw new NotImplementedException(
+        "need to implement the test 'getGroupsFromUser_FindSomeQuery_Success'");
+  }
 
-	@Test
-	public void addGroupsToUser_NonExistentUser_NotFound(){
+  @Test
+  public void addGroupsToUser_NonExistentUser_NotFound() {
     val data = generateUniqueTestUserData();
     val existingGroupIds = convertToIds(data.getGroups());
 
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
-    // Assert that a NOT_FOUND error is thrown when attempting to add existing groups to a non-existing user
+    // Assert that a NOT_FOUND error is thrown when attempting to add existing groups to a
+    // non-existing user
     addGroupsToUserPostRequestAnd(nonExistentId, existingGroupIds).assertNotFound();
-	}
+  }
 
-	@Test
-	public void addGroupsToUser_AllExistingUnassociatedGroups_Success(){
+  @Test
+  public void addGroupsToUser_AllExistingUnassociatedGroups_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert user has no groups
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
 
     // Add groups to user and asser response is a user
     addGroupsToUserPostRequestAnd(user0, data.getGroups())
@@ -785,24 +813,27 @@ public class UserControllerTest extends AbstractControllerTest {
     getGroupsForUserGetRequestAnd(user0)
         .assertPageResultsOfType(Group.class)
         .containsExactlyInAnyOrderElementsOf(data.getGroups());
-	}
+  }
 
-	@Test
-	public void addGroupsToUser_SomeExistingGroupsButAllUnassociated_NotFound(){
+  @Test
+  public void addGroupsToUser_SomeExistingGroupsButAllUnassociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
-    // Assert NOT_FOUND thrown when adding a mix of existing and non-existing applications to an existing user
+    // Assert NOT_FOUND thrown when adding a mix of existing and non-existing applications to an
+    // existing user
     val someExistingGroupIds = mapToSet(data.getGroups(), Identifiable::getId);
-    val nonExistingGroupIds = repeatedCallsOf(() -> generateNonExistentId(groupService), 10).stream().collect(toImmutableSet());
+    val nonExistingGroupIds =
+        repeatedCallsOf(() -> generateNonExistentId(groupService), 10).stream()
+            .collect(toImmutableSet());
     someExistingGroupIds.addAll(nonExistingGroupIds);
 
     addGroupsToUserPostRequestAnd(user0.getId(), someExistingGroupIds).assertNotFound();
-	}
+  }
 
-	@Test
-	public void addGroupsToUser_AllExistingGroupsButSomeAlreadyAssociated_Conflict(){
+  @Test
+  public void addGroupsToUser_AllExistingGroupsButSomeAlreadyAssociated_Conflict() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -810,9 +841,7 @@ public class UserControllerTest extends AbstractControllerTest {
     val group1 = data.getGroups().get(1);
 
     // Assert user has no groups
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
 
     // Add group0 to user and assert response is a user
     addGroupsToUserPostRequestAnd(user0, newArrayList(group0))
@@ -826,10 +855,10 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Add group0 and group1 to user and assert CONFLICT
     addGroupsToUserPostRequestAnd(user0, newArrayList(group0, group1)).assertConflict();
-	}
+  }
 
-	@Test
-	public void removeGroupsFromUser_AllExistingAssociatedGroups_Success(){
+  @Test
+  public void removeGroupsFromUser_AllExistingAssociatedGroups_Success() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -848,13 +877,11 @@ public class UserControllerTest extends AbstractControllerTest {
     deleteGroupsFromUserDeleteRequestAnd(user0, data.getGroups()).assertOk();
 
     // Assert user does not have any groups associated
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
-	}
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
+  }
 
-	@Test
-	public void removeGroupsFromUser_AllExistingGroupsButSomeNotAssociated_NotFound(){
+  @Test
+  public void removeGroupsFromUser_AllExistingGroupsButSomeNotAssociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
@@ -862,9 +889,7 @@ public class UserControllerTest extends AbstractControllerTest {
     val group1 = data.getGroups().get(1);
 
     // Assert user has no groups
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
 
     // Add group0 only to user
     addGroupsToUserPostRequestAnd(user0, newArrayList(group0)).assertOk();
@@ -876,18 +901,16 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Attempt to delete group0 and group1 from user, and assert NOT_FOUND error
     deleteGroupsFromUserDeleteRequestAnd(user0, newArrayList(group0, group1)).assertNotFound();
-	}
+  }
 
-	@Test
-	public void removeGroupsFromUser_SomeNonExistingGroupsButAllAssociated_NotFound(){
+  @Test
+  public void removeGroupsFromUser_SomeNonExistingGroupsButAllAssociated_NotFound() {
     // Generate data
     val data = generateUniqueTestUserData();
     val user0 = data.getUsers().get(0);
 
     // Assert no groups for user
-    getGroupsForUserGetRequestAnd(user0)
-        .assertPageResultsOfType(Group.class)
-        .isEmpty();
+    getGroupsForUserGetRequestAnd(user0).assertPageResultsOfType(Group.class).isEmpty();
 
     // Add all groups to user
     addGroupsToUserPostRequestAnd(user0, data.getGroups()).assertOk();
@@ -901,10 +924,10 @@ public class UserControllerTest extends AbstractControllerTest {
     val groupIdsToDelete = newHashSet(convertToIds(data.getGroups()));
     groupIdsToDelete.add(generateNonExistentId(groupService));
     deleteGroupsFromUserDeleteRequestAnd(user0.getId(), groupIdsToDelete).assertNotFound();
-	}
+  }
 
-	@Test
-	public void removeGroupsFromUser_NonExistentUser_NotFound(){
+  @Test
+  public void removeGroupsFromUser_NonExistentUser_NotFound() {
     // Setup data
     val data = generateUniqueTestUserData();
     val groupIds = convertToIds(data.getGroups());
@@ -912,9 +935,10 @@ public class UserControllerTest extends AbstractControllerTest {
     // Create non existent user id
     val nonExistentId = generateNonExistentId(userService);
 
-    // Assert that a NOT_FOUND error is returned when trying to delete groups from a non-existent user
+    // Assert that a NOT_FOUND error is returned when trying to delete groups from a non-existent
+    // user
     deleteGroupsFromUserDeleteRequestAnd(nonExistentId, groupIds).assertNotFound();
-	}
+  }
 
   @SneakyThrows
   private TestUserData generateUniqueTestUserData() {
@@ -939,5 +963,4 @@ public class UserControllerTest extends AbstractControllerTest {
     @NonNull private final List<Application> applications;
     @NonNull private final List<Policy> policies;
   }
-
 }

--- a/src/test/java/bio/overture/ego/controller/UserControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserControllerTest.java
@@ -41,6 +41,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang.NotImplementedException;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,8 +51,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -87,7 +86,6 @@ import static bio.overture.ego.utils.Joiners.COMMA;
 import static bio.overture.ego.utils.Streams.stream;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newHashSet;
-import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
@@ -183,7 +181,8 @@ public class UserControllerTest extends AbstractControllerTest {
         .containsAll(data.getUsers());
 	}
 
-	@Test
+  @Test
+  @Ignore("low prority, but should be implemented")
 	public void findUsers_FindSomeQuery_Success(){
 		throw new NotImplementedException("need to implement the test 'findUsers_FindSomeQuery_Success'");
 	}
@@ -212,7 +211,7 @@ public class UserControllerTest extends AbstractControllerTest {
     // Assert the user can be read and matches the request data
     val r1 = getUserEntityGetRequestAnd(user)
         .extractOneEntity(User.class);
-    assertThat(r1).isEqualToIgnoringGivenFields(r, ID, USERAPPLICATIONS, USERPERMISSIONS, USERGROUPS, TOKENS, NAME, CREATEDAT);
+    assertThat(r1).isEqualToIgnoringGivenFields(r, ID, USERAPPLICATIONS, USERPERMISSIONS, USERGROUPS, TOKENS, NAME, CREATEDAT, LASTLOGIN);
     assertThat(r1).isEqualToIgnoringGivenFields(user);
 	}
 
@@ -358,7 +357,7 @@ public class UserControllerTest extends AbstractControllerTest {
     // Assert update was correct
     val actualUser1 = getUserEntityGetRequestAnd(user0)
         .extractOneEntity(User.class);
-    assertThat(actualUser1).isEqualToIgnoringGivenFields(r1, TYPE, STATUS, NAME, LASTNAME, PREFERREDLANGUAGE,ID, CREATEDAT, USERPERMISSIONS, USERAPPLICATIONS, USERGROUPS, TOKENS);
+    assertThat(actualUser1).isEqualToIgnoringGivenFields(r1, TYPE, STATUS, NAME, LASTNAME, PREFERREDLANGUAGE,ID, CREATEDAT, LASTLOGIN, USERPERMISSIONS, USERAPPLICATIONS, USERGROUPS, TOKENS);
     assertThat(actualUser1.getFirstName()).isEqualTo(r1.getFirstName());
     assertThat(actualUser1.getEmail()).isEqualTo(r1.getEmail());
     assertThat(actualUser1.getName()).isEqualTo(r1.getEmail());
@@ -411,35 +410,6 @@ public class UserControllerTest extends AbstractControllerTest {
 
     // Assert that a CONFLICT error occurs when trying to update a user with a name that already exists
     partialUpdateUserPutRequestAnd(user0.getId(), r1).assertConflict();
-	}
-
-	@Test
-	public void updateUser_FutureLastLoginDate_BadRequest(){
-    // Generate data
-    val data = generateUniqueTestUserData();
-    val user0 = data.getUsers().get(0);
-
-    // Create update request with same email
-    val futureDate = Date.from(Instant.now().plus(1, DAYS));
-    val r1 = UpdateUserRequest.builder().lastLogin(futureDate).build();
-
-    // Assert that updating with a future last login results in a BAD_REQUEST error
-    partialUpdateUserPutRequestAnd(user0.getId(), r1).assertBadRequest();
-	}
-
-	@Test
-	public void updateUser_LastLoginBeforeCreatedAtDate_BadRequest(){
-    // Generate data
-    val data = generateUniqueTestUserData();
-    val user0 = data.getUsers().get(0);
-
-    // Create update request with same email
-    val timeTravelDate = Date.from(user0.getCreatedAt().toInstant().minus(1, DAYS));
-    assertThat(user0.getCreatedAt().after(timeTravelDate)).isTrue();
-    val r1 = UpdateUserRequest.builder().lastLogin(timeTravelDate).build();
-
-    // Assert that updating with a last login before the created at data results in a BAD_REQUEST error
-    partialUpdateUserPutRequestAnd(user0.getId(), r1).assertBadRequest();
 	}
 
 	@Test
@@ -575,8 +545,9 @@ public class UserControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+  @Ignore("low priority, but should be implemented")
 	public void getApplicationsFromUser_FindSomeQuery_Success(){
-		throw new NotImplementedException("need to implement the test 'getApplicationsFromUser_FindSomeQuery_Success'");
+    throw new NotImplementedException("need to implement");
 	}
 
 	@Test
@@ -777,6 +748,7 @@ public class UserControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+  @Ignore("low priority, but should be implemented")
 	public void getGroupsFromUser_FindSomeQuery_Success(){
 		throw new NotImplementedException("need to implement the test 'getGroupsFromUser_FindSomeQuery_Success'");
 	}

--- a/src/test/java/bio/overture/ego/service/ApplicationServiceTest.java
+++ b/src/test/java/bio/overture/ego/service/ApplicationServiceTest.java
@@ -1,32 +1,5 @@
 package bio.overture.ego.service;
 
-import bio.overture.ego.controller.resolver.PageableResolver;
-import bio.overture.ego.model.dto.CreateApplicationRequest;
-import bio.overture.ego.model.dto.UpdateApplicationRequest;
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.exceptions.NotFoundException;
-import bio.overture.ego.model.exceptions.UniqueViolationException;
-import bio.overture.ego.model.search.SearchFilter;
-import bio.overture.ego.repository.ApplicationRepository;
-import bio.overture.ego.token.app.AppTokenClaims;
-import bio.overture.ego.utils.EntityGenerator;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.provider.ClientRegistrationException;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
-
 import static bio.overture.ego.model.enums.StatusType.APPROVED;
 import static bio.overture.ego.model.enums.StatusType.DISABLED;
 import static bio.overture.ego.model.enums.StatusType.PENDING;
@@ -39,6 +12,32 @@ import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import bio.overture.ego.controller.resolver.PageableResolver;
+import bio.overture.ego.model.dto.CreateApplicationRequest;
+import bio.overture.ego.model.dto.UpdateApplicationRequest;
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.exceptions.NotFoundException;
+import bio.overture.ego.model.exceptions.UniqueViolationException;
+import bio.overture.ego.model.search.SearchFilter;
+import bio.overture.ego.repository.ApplicationRepository;
+import bio.overture.ego.token.app.AppTokenClaims;
+import bio.overture.ego.utils.EntityGenerator;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @SpringBootTest

--- a/src/test/java/bio/overture/ego/service/ApplicationServiceTest.java
+++ b/src/test/java/bio/overture/ego/service/ApplicationServiceTest.java
@@ -1,18 +1,5 @@
 package bio.overture.ego.service;
 
-import static bio.overture.ego.model.enums.StatusType.APPROVED;
-import static bio.overture.ego.model.enums.StatusType.DISABLED;
-import static bio.overture.ego.model.enums.StatusType.PENDING;
-import static bio.overture.ego.model.enums.StatusType.REJECTED;
-import static bio.overture.ego.service.ApplicationService.APPLICATION_CONVERTER;
-import static bio.overture.ego.utils.CollectionUtils.setOf;
-import static bio.overture.ego.utils.EntityGenerator.generateNonExistentId;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Collections.singletonList;
-import static java.util.UUID.randomUUID;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import bio.overture.ego.controller.resolver.PageableResolver;
 import bio.overture.ego.model.dto.CreateApplicationRequest;
 import bio.overture.ego.model.dto.UpdateApplicationRequest;
@@ -23,9 +10,6 @@ import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.ApplicationRepository;
 import bio.overture.ego.token.app.AppTokenClaims;
 import bio.overture.ego.utils.EntityGenerator;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.Ignore;
@@ -38,6 +22,23 @@ import org.springframework.security.oauth2.provider.ClientRegistrationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.StatusType.APPROVED;
+import static bio.overture.ego.model.enums.StatusType.DISABLED;
+import static bio.overture.ego.model.enums.StatusType.PENDING;
+import static bio.overture.ego.model.enums.StatusType.REJECTED;
+import static bio.overture.ego.service.ApplicationService.APPLICATION_CONVERTER;
+import static bio.overture.ego.utils.CollectionUtils.setOf;
+import static bio.overture.ego.utils.EntityGenerator.generateNonExistentId;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.singletonList;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @Slf4j
 @SpringBootTest
@@ -72,7 +73,6 @@ public class ApplicationServiceTest {
             .name(name)
             .status(status)
             .redirectUri(null)
-            .users(null)
             .build();
 
     val newName = randomUUID().toString();
@@ -93,7 +93,7 @@ public class ApplicationServiceTest {
     assertThat(app.getStatus()).isEqualTo(APPROVED);
     assertThat(app.getId()).isEqualTo(id);
     assertThat(app.getName()).isEqualTo(newName);
-    assertThat(app.getUsers()).isNull();
+    assertThat(app.getUserApplications()).isNull();
   }
 
   @Test
@@ -111,7 +111,7 @@ public class ApplicationServiceTest {
     assertThat(app.getGroupApplications()).isEmpty();
     assertThat(app.getClientId()).isEqualTo(req.getClientId());
     assertThat(app.getName()).isEqualTo(req.getName());
-    assertThat(app.getUsers()).isEmpty();
+    assertThat(app.getUserApplications()).isEmpty();
     assertThat(app.getClientSecret()).isEqualTo(req.getClientSecret());
     assertThat(app.getStatus()).isEqualTo(req.getStatus());
     assertThat(app.getDescription()).isNull();
@@ -238,8 +238,8 @@ public class ApplicationServiceTest {
 
     val application = applicationService.getByClientId("444444");
 
-    userService.addUserToApps(user.getId(), newArrayList(application.getId()));
-    userService.addUserToApps(userTwo.getId(), newArrayList(application.getId()));
+    userService.associateApplicationsWithUser(user.getId(), newArrayList(application.getId()));
+    userService.associateApplicationsWithUser(userTwo.getId(), newArrayList(application.getId()));
 
     val applications =
         applicationService.findApplicationsForUser(
@@ -271,7 +271,7 @@ public class ApplicationServiceTest {
     val applicationOne = applicationService.getByClientId("111111");
     val applicationTwo = applicationService.getByClientId("555555");
 
-    userService.addUserToApps(
+    userService.associateApplicationsWithUser(
         user.getId(), newArrayList(applicationOne.getId(), applicationTwo.getId()));
 
     val clientIdFilter = new SearchFilter("clientId", "111111");
@@ -293,7 +293,7 @@ public class ApplicationServiceTest {
     val applicationOne = applicationService.getByClientId("333333");
     val applicationTwo = applicationService.getByClientId("444444");
 
-    userService.addUserToApps(
+    userService.associateApplicationsWithUser(
         user.getId(), newArrayList(applicationOne.getId(), applicationTwo.getId()));
 
     val clientIdFilter = new SearchFilter("clientId", "333333");
@@ -317,7 +317,7 @@ public class ApplicationServiceTest {
     val applicationOne = applicationService.getByClientId("222222");
     val applicationTwo = applicationService.getByClientId("444444");
 
-    userService.addUserToApps(
+    userService.associateApplicationsWithUser(
         user.getId(), newArrayList(applicationOne.getId(), applicationTwo.getId()));
 
     val applications =

--- a/src/test/java/bio/overture/ego/service/UserServiceTest.java
+++ b/src/test/java/bio/overture/ego/service/UserServiceTest.java
@@ -1,37 +1,5 @@
 package bio.overture.ego.service;
 
-import bio.overture.ego.controller.resolver.PageableResolver;
-import bio.overture.ego.model.dto.CreateUserRequest;
-import bio.overture.ego.model.dto.PermissionRequest;
-import bio.overture.ego.model.dto.UpdateUserRequest;
-import bio.overture.ego.model.entity.AbstractPermission;
-import bio.overture.ego.model.entity.Application;
-import bio.overture.ego.model.entity.User;
-import bio.overture.ego.model.exceptions.NotFoundException;
-import bio.overture.ego.model.exceptions.UniqueViolationException;
-import bio.overture.ego.model.search.SearchFilter;
-import bio.overture.ego.token.IDToken;
-import bio.overture.ego.utils.Converters;
-import bio.overture.ego.utils.EntityGenerator;
-import bio.overture.ego.utils.PolicyPermissionUtils;
-import com.google.common.collect.ImmutableList;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import static bio.overture.ego.model.enums.AccessLevel.DENY;
 import static bio.overture.ego.model.enums.AccessLevel.READ;
 import static bio.overture.ego.model.enums.AccessLevel.WRITE;
@@ -50,6 +18,37 @@ import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import bio.overture.ego.controller.resolver.PageableResolver;
+import bio.overture.ego.model.dto.CreateUserRequest;
+import bio.overture.ego.model.dto.PermissionRequest;
+import bio.overture.ego.model.dto.UpdateUserRequest;
+import bio.overture.ego.model.entity.AbstractPermission;
+import bio.overture.ego.model.entity.Application;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.exceptions.NotFoundException;
+import bio.overture.ego.model.exceptions.UniqueViolationException;
+import bio.overture.ego.model.search.SearchFilter;
+import bio.overture.ego.token.IDToken;
+import bio.overture.ego.utils.Converters;
+import bio.overture.ego.utils.EntityGenerator;
+import bio.overture.ego.utils.PolicyPermissionUtils;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @SpringBootTest
@@ -654,7 +653,9 @@ public class UserServiceTest {
     val appId = app.getId();
 
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> userService.associateApplicationsWithUser(NON_EXISTENT_USER, singletonList(appId)));
+        .isThrownBy(
+            () ->
+                userService.associateApplicationsWithUser(NON_EXISTENT_USER, singletonList(appId)));
   }
 
   @Test
@@ -809,7 +810,10 @@ public class UserServiceTest {
     userService.associateApplicationsWithUser(userId, asList(appId, appTwoId));
 
     assertThatExceptionOfType(NotFoundException.class)
-        .isThrownBy(() -> userService.disassociateApplicationsFromUser(NON_EXISTENT_USER, singletonList(appId)));
+        .isThrownBy(
+            () ->
+                userService.disassociateApplicationsFromUser(
+                    NON_EXISTENT_USER, singletonList(appId)));
   }
 
   @Test

--- a/src/test/java/bio/overture/ego/service/UserServiceTest.java
+++ b/src/test/java/bio/overture/ego/service/UserServiceTest.java
@@ -556,7 +556,6 @@ public class UserServiceTest {
             .lastName("Exist")
             .status(APPROVED)
             .preferredLanguage(ENGLISH)
-            .lastLogin(null)
             .type(ADMIN)
             .build();
     assertThatExceptionOfType(NotFoundException.class)


### PR DESCRIPTION
Related to #330 

- Removed `@ManyToMany` and replaced with 2 `@OneToMany` with a join entity (`UserApplications`)
- Removed `lastLogin` from `UpdateUserRequest`. The `lastLogin` field should only be updated by the application, not by the user agent
- Removed useless jpa annotation arguments (refer to this [link](https://thoughts-on-java.org/hibernate-tips-whats-the-difference-between-column-nullable-false-and-notnull/))
- Add 36 User Controller tests