### PR TITLE
JWT Spec implementation and cleanup

### DIFF
--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -22,6 +22,7 @@ import static bio.overture.ego.service.UserService.resolveUsersPermissions;
 import static bio.overture.ego.utils.CollectionUtils.mapToImmutableSet;
 import static bio.overture.ego.utils.PolicyPermissionUtils.extractPermissionStrings;
 import static com.google.common.collect.Sets.newHashSet;
+import static java.util.stream.Collectors.toList;
 
 import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.enums.JavaFields;
@@ -198,9 +199,22 @@ public class User implements PolicyOwner, NameableEntity<UUID> {
   // JsonViews creates
   // a dependency for this method. For now, using a UserService static method.
   // Creates permissions in JWTAccessToken::context::user
-  @JsonView(Views.JWTAccessToken.class)
+  @JsonIgnore
   public List<String> getPermissions() {
     return extractPermissionStrings(resolveUsersPermissions(this));
+  }
+
+  /**
+   * Gets the groups that the user belongs to as a List of groups ids. Meant for use in the
+   * JWTAccessToken JsonView for serialization
+   *
+   * @return List of group IDs
+   */
+  @JsonView(Views.JWTAccessToken.class)
+  public List<String> getGroups() {
+    return this.getUserGroups().stream()
+        .map(userGroup -> userGroup.getGroup().getId().toString())
+        .collect(toList()); // Cannot be unmodifiable due to Jackson serialization
   }
 
   /*

--- a/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
+++ b/src/main/java/bio/overture/ego/token/user/UserTokenClaims.java
@@ -22,7 +22,6 @@ import bio.overture.ego.token.TokenClaims;
 import bio.overture.ego.view.Views;
 import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -42,10 +41,6 @@ public class UserTokenClaims extends TokenClaims {
     } else {
       return sub;
     }
-  }
-
-  public Set<String> getScope() {
-    return this.context.getScope();
   }
 
   public List<String> getAud() {

--- a/src/test/java/bio/overture/ego/token/JwtTest.java
+++ b/src/test/java/bio/overture/ego/token/JwtTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package bio.overture.ego.token;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import bio.overture.ego.AuthorizationServiceMain;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.enums.LanguageType;
+import bio.overture.ego.model.enums.StatusType;
+import bio.overture.ego.service.TokenService;
+import java.util.*;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@Slf4j
+@ActiveProfiles({"test"})
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    classes = AuthorizationServiceMain.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class JwtTest {
+
+  /** Dependencies */
+  @Autowired private TokenService tokenService;
+
+  @Test
+  @SuppressWarnings("unchecked")
+  @SneakyThrows
+  public void jwtContainsUserGroups() {
+    val groupId = UUID.randomUUID().toString();
+
+    User user =
+        Mockito.spy(
+            User.builder()
+                .id(UUID.randomUUID())
+                .email("foobar@example.com")
+                .name("foobar@example.com")
+                .firstName("foo")
+                .lastName("bar")
+                .status(StatusType.APPROVED)
+                .preferredLanguage(LanguageType.ENGLISH)
+                .build());
+
+    Mockito.when(user.getGroups()).thenReturn(List.of(groupId));
+
+    // Generate Token String
+    val token = tokenService.generateUserToken(user);
+
+    // Parsing the token to verify groups are there
+    val claims = tokenService.getTokenClaims(token);
+    val userClaims = claims.get("context", LinkedHashMap.class);
+    Map<String, Object> userInfo = (Map<String, Object>) userClaims.get("user");
+    val groups = (Collection<String>) userInfo.get("groups");
+    assertEquals(1, groups.size());
+    assertTrue(groups.contains(groupId));
+  }
+}


### PR DESCRIPTION
## Summary 
Implementation for: https://github.com/overture-stack/ego/issues/390
Follows spec here: https://wiki.oicr.on.ca/display/icgcargotech/JWT+Specification

## Code Changes
- Removed scopes from root of JWT Token Claims
- JSON Ignored the permissions so they don't show up in user info of claims
- Added getter for Group IDs for JSON Serialization of JWT
- Added Unit test of functionality 