### PR TITLE
updates dependencies for jdk11 and vault

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.4.RELEASE</version>
+        <version>2.1.8.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -205,8 +205,8 @@
         <!-- Vault -->
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-vault-starter-config</artifactId>
-            <version>LATEST</version>
+            <artifactId>spring-cloud-starter-vault-config</artifactId>
+            <version>2.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -379,7 +379,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Finchley.M8</version>
+                <version>Greenwich.SR2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -397,6 +397,10 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>spring-releases</id>
+            <url>https://repo.spring.io/libs-release</url>
         </repository>
         <repository>
             <id>spring-milestones</id>

--- a/src/main/resources/bootstrap-token.properties
+++ b/src/main/resources/bootstrap-token.properties
@@ -1,8 +1,9 @@
 spring.cloud.vault.enabled=true
-spring.application.name=development/oicr/ego
+spring.application.name=ego-dev
 spring.cloud.vault.generic.default-context=${spring.application.name}
+spring.cloud.vault.kv.backend-version=1
+spring.cloud.vault.generic.backend=ego
 spring.cloud.vault.scheme=http
 spring.cloud.vault.host=localhost
 spring.cloud.vault.port=8200
-spring.cloud.vault.token=413b7605-faa8-8b67-cb2a-5ee09b877dbc
-
+spring.cloud.vault.token=00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
Turns out when we jumped to JDK11 we broke the spring cloud config dependency but since we for the most part were not using it until now, we have not noticed.

This PR fixes that. 