### PR TITLE
Database indices and perf fix to group code

### DIFF
--- a/src/main/java/bio/overture/ego/event/token/CleanupTokenListener.java
+++ b/src/main/java/bio/overture/ego/event/token/CleanupTokenListener.java
@@ -47,6 +47,7 @@ public class CleanupTokenListener implements ApplicationListener<CleanupUserToke
 
   @Override
   public void onApplicationEvent(@NonNull CleanupUserTokensEvent event) {
+    log.debug("Number of users to be checked for token cleanup: {}", event.getUsers().size());
     cleanupTokens(event.getUsers());
   }
 
@@ -57,7 +58,6 @@ public class CleanupTokenListener implements ApplicationListener<CleanupUserToke
   private void cleanupTokensForUser(@NonNull User user) {
     val scopes = tokenService.userScopes(user.getName()).getScopes();
     val tokens = tokenService.listToken(user.getId());
-
     tokens.forEach(t -> verifyToken(t, scopes));
   }
 

--- a/src/main/java/bio/overture/ego/service/GroupService.java
+++ b/src/main/java/bio/overture/ego/service/GroupService.java
@@ -210,7 +210,7 @@ public class GroupService extends AbstractNamedService<Group, UUID> {
     nonAssociatedUsers.stream()
         .map(u -> convertToUserGroup(u, groupWithUserGroups))
         .forEach(UserGroupService::associateSelf);
-    tokenEventsPublisher.requestTokenCleanupByUsers(users);
+    tokenEventsPublisher.requestTokenCleanupByUsers(nonAssociatedUsers);
     return groupWithUserGroups;
   }
 

--- a/src/main/java/bio/overture/ego/service/GroupService.java
+++ b/src/main/java/bio/overture/ego/service/GroupService.java
@@ -180,7 +180,13 @@ public class GroupService extends AbstractNamedService<Group, UUID> {
             .collect(toImmutableSet());
 
     disassociateUserGroupsFromGroup(groupWithUserGroups, userGroupsToDisassociate);
-    tokenEventsPublisher.requestTokenCleanupByUsers(users);
+
+    // Only request cleanup check for disassociated users
+    val usersToCheck =
+        users.stream()
+            .filter(u -> userIdsToDisassociate.contains(u.getId()))
+            .collect(toImmutableSet());
+    tokenEventsPublisher.requestTokenCleanupByUsers(usersToCheck);
   }
 
   public Group associateUsersWithGroup(@NonNull UUID id, @NonNull Collection<UUID> userIds) {

--- a/src/main/resources/flyway/sql/V1_14__indices.sql
+++ b/src/main/resources/flyway/sql/V1_14__indices.sql
@@ -1,0 +1,15 @@
+CREATE INDEX idx_usergroup_user ON usergroup(user_id);
+CREATE INDEX idx_usergroup_group ON usergroup(group_id);
+CREATE INDEX idx_usergroup_both ON usergroup(user_id, group_id);
+
+CREATE INDEX idx_userpermission_user ON userpermission(user_id);
+CREATE INDEX idx_userpermission_policy ON userpermission(policy_id);
+CREATE INDEX idx_userpermission_both ON userpermission(user_id, policy_id);
+
+CREATE INDEX idx_grouppermission_group ON grouppermission(group_id);
+CREATE INDEX idx_grouppermission_policy ON grouppermission(policy_id);
+CREATE INDEX idx_grouppermission_both ON grouppermission(group_id, policy_id);
+
+CREATE INDEX idx_token_owner ON token(owner);
+CREATE INDEX idx_tokenscope ON tokenscope(token_id, policy_id, access_level);
+CREATE INDEX idx_tokenscope_policy ON tokenscope(policy_id);


### PR DESCRIPTION
This fixes a performance issue related to how tokens were checked/cleaned up. Previously if a user was added to a group, the code would re-verify the tokens for every user in the group which is expensive. 

Also includes database indexes to speed up certain common joins.  

**Previous runtime of Daco2Ego:** Killed after 2+ hours
**New runtime of Daco2Ego:** 16 minutes

#364