### PR TITLE
Allows clients to specify redirect_uri query param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 </p>
 
 [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=U3dLZnRFNWI2MWNFY2NGcXVtVTB3WDcyU2dPVjlVeEFYUEdxUnpYZlhrUT0tLTFzY0taYTA0MVFEa3ErNkRZdTBRWVE9PQ==--690f89a41a0eedf7b4975bd7df2eac162e04e775% )](https://www.browserstack.com/automate/public-build/U3dLZnRFNWI2MWNFY2NGcXVtVTB3WDcyU2dPVjlVeEFYUEdxUnpYZlhrUT0tLTFzY0taYTA0MVFEa3ErNkRZdTBRWVE9PQ==--690f89a41a0eedf7b4975bd7df2eac162e04e775%)
-[![Build Status](https://travis-ci.org/overture-stack/ego.svg?branch=master)](https://travis-ci.org/overture-stack/ego)
-[![CircleCI](https://circleci.com/gh/overture-stack/ego/tree/develop.svg?style=svg)](https://circleci.com/gh/overture-stack/ego/tree/develop)
 [![Slack](http://slack.overture.bio/badge.svg)](http://slack.overture.bio)
 
 ## Table of Contents

--- a/src/main/java/bio/overture/ego/security/CorsFilter.java
+++ b/src/main/java/bio/overture/ego/security/CorsFilter.java
@@ -16,14 +16,15 @@
 
 package bio.overture.ego.security;
 
-import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.service.ApplicationService;
+import bio.overture.ego.utils.Redirects;
 import java.net.URI;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -44,12 +45,13 @@ public class CorsFilter implements Filter {
     final HttpServletRequest request = (HttpServletRequest) req;
 
     String clientId = request.getParameter("client_id");
+    String redirectUri = request.getParameter("redirect_uri");
 
     // allow ego app access token at /oauth/ego-token
     if (clientId != null) {
       try {
-        Application app = applicationService.getByClientId(clientId);
-        URI uri = new URI(app.getRedirectUri());
+        val app = applicationService.getByClientId(clientId);
+        val uri = new URI(Redirects.getRedirectUri(app, redirectUri));
         response.setHeader(
             "Access-Control-Allow-Origin",
             uri.getScheme()

--- a/src/main/java/bio/overture/ego/utils/Redirects.java
+++ b/src/main/java/bio/overture/ego/utils/Redirects.java
@@ -43,7 +43,7 @@ public class Redirects {
     val redirects = Arrays.stream(app.getRedirectUri().split(","));
 
     // Short return if no redirect URI is provided
-    if (redirect == null || redirect.isEmpty()) {
+    if (redirect == null || redirect.isBlank()) {
       return redirects
           .findFirst()
           .orElseThrow(() -> new UnauthorizedClientException("Cannot find valid redirect URI"));

--- a/src/main/java/bio/overture/ego/utils/Redirects.java
+++ b/src/main/java/bio/overture/ego/utils/Redirects.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2019. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package bio.overture.ego.utils;
+
+import static java.lang.String.format;
+
+import bio.overture.ego.model.entity.Application;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Objects;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.security.oauth2.common.exceptions.UnauthorizedClientException;
+
+@Slf4j
+public class Redirects {
+
+  /**
+   * Returns redirect uri based Declares a runtime exception to be explicit
+   *
+   * @return Returns URI as a String that Ego will redirect to
+   */
+  public static String getRedirectUri(@NonNull Application app, String redirect) {
+    val redirects = Arrays.stream(app.getRedirectUri().split(","));
+
+    // Short return if no redirect URI is provided
+    if (redirect == null || redirect.isEmpty()) {
+      return redirects
+          .findFirst()
+          .orElseThrow(() -> new UnauthorizedClientException("Cannot find valid redirect URI"));
+    }
+
+    val msg = format("Unauthorized redirect URI: %s", redirect);
+    URI redirectUri;
+    try {
+      redirectUri = new URI(redirect);
+    } catch (URISyntaxException e) {
+      log.error(msg);
+      throw new UnauthorizedClientException(msg);
+    }
+
+    val isValid =
+        redirects
+            .map(
+                r -> {
+                  try {
+                    return new URI(r);
+                  } catch (URISyntaxException e) {
+                    log.error(
+                        format(
+                            "Could not parse URI in getRedirectUriOrThrow for clientId: %s %s",
+                            app.getClientId(), r),
+                        e);
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .map(
+                u ->
+                    u.getHost().equals(redirectUri.getHost())
+                        && u.getPort() == redirectUri.getPort()) // Map to valid/invalid
+            .reduce(Boolean::logicalOr) // Needs at least one valid
+            .orElse(false);
+
+    if (isValid) {
+      return redirect;
+    } else {
+      log.error(msg);
+      throw new UnauthorizedClientException(msg);
+    }
+  }
+}

--- a/src/test/java/bio/overture/ego/utils/RedirectsTest.java
+++ b/src/test/java/bio/overture/ego/utils/RedirectsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2019. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package bio.overture.ego.utils;
+
+import static bio.overture.ego.utils.Redirects.*;
+import static org.junit.Assert.*;
+
+import bio.overture.ego.model.entity.Application;
+import lombok.val;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.security.oauth2.common.exceptions.UnauthorizedClientException;
+
+public class RedirectsTest {
+
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testNullRedirect() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, null);
+    assertEquals("https://example.com", redirect);
+  }
+
+  @Test
+  public void testEmptyRedirect() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "");
+    assertEquals("https://example.com", redirect);
+  }
+
+  @Test
+  public void testSameDomainNoPath() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "https://example.com");
+    assertEquals("https://example.com", redirect);
+  }
+
+  @Test
+  public void testSameDomainWithPath() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "https://example.com/foobar");
+    assertEquals("https://example.com/foobar", redirect);
+  }
+
+  @Test
+  public void testFirstFromList() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+
+    val redirect = getRedirectUri(app, "");
+    assertEquals("https://example.com:5555", redirect);
+  }
+
+  @Test
+  public void testExactFromList() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+
+    val redirect = getRedirectUri(app, "https://other.example.com");
+    assertEquals("https://other.example.com", redirect);
+  }
+
+  @Test
+  public void testPathFromList() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+
+    val redirect = getRedirectUri(app, "https://other.example.com/super/secret/path");
+    assertEquals("https://other.example.com/super/secret/path", redirect);
+  }
+
+  @Test
+  public void testWrongPort() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+    exceptionRule.expect(UnauthorizedClientException.class);
+    getRedirectUri(app, "https://example.com:8080");
+  }
+
+  @Test
+  public void testWrongScheme() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+    exceptionRule.expect(UnauthorizedClientException.class);
+    getRedirectUri(app, "http://example.com:8080");
+  }
+
+  private static Application appWithUrls(String urls) {
+    val app = new Application();
+    app.setRedirectUri(urls);
+    return app;
+  }
+}

--- a/src/test/java/bio/overture/ego/utils/RedirectsTest.java
+++ b/src/test/java/bio/overture/ego/utils/RedirectsTest.java
@@ -48,6 +48,14 @@ public class RedirectsTest {
   }
 
   @Test
+  public void testBlankRedirect() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "          ");
+    assertEquals("https://example.com", redirect);
+  }
+
+  @Test
   public void testSameDomainNoPath() {
     val app = appWithUrls("https://example.com");
 
@@ -56,11 +64,27 @@ public class RedirectsTest {
   }
 
   @Test
+  public void testSameDomainNoPathWithParams() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "https://example.com?foo=1&bar=2");
+    assertEquals("https://example.com?foo=1&bar=2", redirect);
+  }
+
+  @Test
   public void testSameDomainWithPath() {
     val app = appWithUrls("https://example.com");
 
     val redirect = getRedirectUri(app, "https://example.com/foobar");
     assertEquals("https://example.com/foobar", redirect);
+  }
+
+  @Test
+  public void testSameDomainWithPathAndParams() {
+    val app = appWithUrls("https://example.com");
+
+    val redirect = getRedirectUri(app, "https://example.com/foobar?over=9000");
+    assertEquals("https://example.com/foobar?over=9000", redirect);
   }
 
   @Test
@@ -85,6 +109,22 @@ public class RedirectsTest {
 
     val redirect = getRedirectUri(app, "https://other.example.com/super/secret/path");
     assertEquals("https://other.example.com/super/secret/path", redirect);
+  }
+
+  @Test
+  public void testPathFromListWithParam() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+
+    val redirect = getRedirectUri(app, "https://other.example.com/super/secret/path?maximum=power");
+    assertEquals("https://other.example.com/super/secret/path?maximum=power", redirect);
+  }
+
+  @Test
+  public void testPathFromListWithParams() {
+    val app = appWithUrls("https://example.com:5555,https://other.example.com,https://google.ca");
+
+    val redirect = getRedirectUri(app, "https://other.example.com/super/secret/path?foo=1&bar=2");
+    assertEquals("https://other.example.com/super/secret/path?foo=1&bar=2", redirect);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Provides support for clients to provide a redirect URI as a query param `redirect_uri`.  Applications should register a comma-delimited list of redirect URIs in the redirect uri fields. Redirect URIs just have to match the same authority (domain and port) and can be of dynamic path. If no redirect URI is present, the first valid URI from the list is used verbatim. 

## Changes
- new query param `redirect_uri` added to login flow
- persistence of redirection to session nonce
- CORS validation with redirect uri 
- Utility class `Redirects` for correctly matching a redirect uri and verifying validity
- Unit tests
- Removed unused badges from README


