### PR TITLE
448 Fixed UserPermissions queries for /policy/{}/users endpoint

### DIFF
--- a/src/main/java/bio/overture/ego/controller/PolicyController.java
+++ b/src/main/java/bio/overture/ego/controller/PolicyController.java
@@ -266,7 +266,8 @@ public class PolicyController {
       @ApiIgnore @Filters List<SearchFilter> filters,
       Pageable pageable) {
     if (isEmpty(query)) {
-      return new PageDTO(userPermissionService.listUserPermissionsByPolicy(id, filters, pageable));
+      return new PageDTO<>(
+          userPermissionService.listUserPermissionsByPolicy(id, filters, pageable));
     } else {
       return new PageDTO<>(
           userPermissionService.findUserPermissionsByPolicy(id, filters, query, pageable));

--- a/src/main/java/bio/overture/ego/model/entity/AbstractPermission.java
+++ b/src/main/java/bio/overture/ego/model/entity/AbstractPermission.java
@@ -22,12 +22,14 @@ import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
 @Data
 @MappedSuperclass
+@FieldNameConstants
 @EqualsAndHashCode(of = {"id"})
 @ToString(exclude = {"policy"})
 @TypeDef(name = EGO_ACCESS_LEVEL_ENUM, typeClass = PostgreSQLEnumType.class)

--- a/src/main/java/bio/overture/ego/model/entity/UserPermission.java
+++ b/src/main/java/bio/overture/ego/model/entity/UserPermission.java
@@ -18,6 +18,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 
 @Entity
 @Table(name = Tables.USER_PERMISSION)
@@ -27,6 +28,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @JsonView(Views.REST.class)
 @ToString(callSuper = true)
+@FieldNameConstants
 @EqualsAndHashCode(
     callSuper = true,
     of = {"id"})

--- a/src/main/java/bio/overture/ego/repository/queryspecification/SimpleCriteriaBuilder.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/SimpleCriteriaBuilder.java
@@ -1,0 +1,81 @@
+package bio.overture.ego.repository.queryspecification;
+
+import bio.overture.ego.model.search.SearchFilter;
+import bio.overture.ego.utils.QueryUtils;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Fetch;
+import javax.persistence.criteria.From;
+import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Predicate;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static bio.overture.ego.model.enums.JavaFields.ID;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static javax.persistence.criteria.JoinType.LEFT;
+import static lombok.AccessLevel.PRIVATE;
+
+@RequiredArgsConstructor(access = PRIVATE)
+public class SimpleCriteriaBuilder<X,Y>{
+  @NonNull private final From<X,Y> from;
+  @NonNull private final CriteriaBuilder builder;
+  @NonNull private final CriteriaQuery<?> query;
+  public static <X,Y> SimpleCriteriaBuilder<X,Y> of(From<X,Y> from, CriteriaBuilder builder, CriteriaQuery<?> query){
+    return new SimpleCriteriaBuilder<>(from, builder, query);
+  }
+
+  // [rtisma] Vlad said to do this:
+  // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+  // Calling from.fetch followed by a from.join results in redundant join sql statements.
+  @SuppressWarnings("unchecked")
+  public <T> SimpleCriteriaBuilder<Y, T> leftJoinFetch(
+      Class<T> joinClass, String joinField) {
+    Fetch<Y, T> fetch = from.fetch(joinField, LEFT);
+    val join = (Join<Y, T>) fetch;
+    return new SimpleCriteriaBuilder<>(join, builder, query);
+  }
+
+  public void setDistinct(boolean distinct){
+    query.distinct(distinct);
+  }
+
+  public Predicate and(Predicate ... andPredicates){
+    return builder.and(andPredicates);
+  }
+
+  public Predicate or(Predicate ... orPredicates){
+    return builder.or(orPredicates);
+  }
+
+  public Collection<Predicate> searchFilter(@NonNull List<SearchFilter> filters) {
+    return filters.stream()
+        .map(f -> filterByField(f.getFilterField(), f.getFilterValue()))
+        .collect(toUnmodifiableList());
+  }
+
+  public Predicate filterByField( @NonNull String fieldName, String fieldValue) {
+    val finalText = QueryUtils.prepareForQuery(fieldValue);
+
+    // Cast "as" String so that we can search ENUM types
+    return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
+  }
+
+  public <T> Predicate matchField(@NonNull String fieldName, @NonNull Class<T> valueType, @NonNull T fieldValue ) {
+    return builder.equal(from.<T>get(fieldName).as(valueType), fieldValue);
+  }
+
+  public Predicate matchStringField(@NonNull String fieldName,@NonNull String fieldValue ) {
+    return builder.equal(from.<String>get(fieldName).as(String.class), fieldValue);
+  }
+
+  public Predicate equalId(@NonNull UUID id) {
+    return builder.equal(from.<Integer>get(ID), id);
+  }
+
+}

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
@@ -50,11 +50,11 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
   public static Specification<UserPermission> buildFilterAndQuerySpecification(
       @NonNull UUID policyId, @NonNull List<SearchFilter> filters, String text) {
     return (root, query, builder) -> {
-      val sp = SimpleCriteriaBuilder.of(root, builder, query);
-      sp.setDistinct(true);
+      val scb = SimpleCriteriaBuilder.of(root, builder, query);
+      scb.setDistinct(true);
       // Create joins
-      val policySp = sp.leftJoinFetch(Policy.class, policy);
-      val userSp = sp.leftJoinFetch(User.class, owner);
+      val policySp = scb.leftJoinFetch(Policy.class, policy);
+      val userSp = scb.leftJoinFetch(User.class, owner);
 
       // Create predicates for filtering by policyId AND searchFilters
       val filterPredicates = userSp.searchFilter(filters);
@@ -69,7 +69,7 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
         val queryPredicates = Lists.<Predicate>newArrayList();
         val finalText = QueryUtils.prepareForQuery(text);
         // UserPermission.accessLevel
-        queryPredicates.add(sp.matchStringField(accessLevel, finalText));
+        queryPredicates.add(scb.matchStringField(accessLevel, finalText));
 
         // User.id and User.name
         Stream.of(id, name)

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
@@ -17,45 +17,173 @@
 package bio.overture.ego.repository.queryspecification;
 
 import static bio.overture.ego.model.enums.JavaFields.*;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Streams.concat;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static javax.persistence.criteria.JoinType.LEFT;
 
 import bio.overture.ego.model.entity.*;
+import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.utils.QueryUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Fetch;
+import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
+import javax.persistence.criteria.Predicate;
+
+import com.google.common.collect.Lists;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.data.jpa.domain.Specification;
 
+@Slf4j
 public class UserPermissionSpecification extends SpecificationBase<UserPermission> {
 
+  @SuppressWarnings("unchecked")
   public static Specification<UserPermission> withPolicy(@NonNull UUID policyId) {
     return (root, query, builder) -> {
       query.distinct(true);
 
-      Join<UserPermission, Policy> userPermissionPolicyJoin = root.join(POLICY);
+      // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+      // Calling fetch followed by a join results in redundant join sql statements.
+      Fetch<UserPermission, Policy> userPermissionPolicyFetch= root.fetch(POLICY, LEFT);
+      Join<UserPermission, Policy> userPermissionPolicyJoin = (Join<UserPermission, Policy>) userPermissionPolicyFetch;
       return builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId);
     };
   }
 
-  public static Specification<UserPermission> withUser(@NonNull UUID userId) {
-    return (root, query, builder) -> {
-      query.distinct(true);
-      Join<UserPermission, Policy> applicationJoin = root.join(OWNER);
-      return builder.equal(applicationJoin.<Integer>get(ID), userId);
-    };
-  }
-
+  @SuppressWarnings("unchecked")
   public static Specification<UserPermission> containsText(@NonNull String text) {
     val finalText = QueryUtils.prepareForQuery(text);
 
-    // TODO: these joins are not working
+    // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
     return (root, query, builder) -> {
-      Join<UserPermission, User> userPermissionJoin = root.join(OWNER);
+//      Fetch<UserPermission, User> userPermissionFetch = root.fetch(OWNER, LEFT);
+//      Join<UserPermission, User> userPermissionJoin = (Join<UserPermission, User>) userPermissionFetch;
+      Join<UserPermission, User> userPermissionJoin = root.join(OWNER,LEFT);
 
       query.distinct(true);
-      return builder.or(
-          getQueryPredicatesForJoin(builder, userPermissionJoin, finalText, ID, NAME, ACCESS_LEVEL));
-      //      return builder.or(getQueryPredicates(builder, root, finalText, ID, ACCESS_LEVEL));
+      val predicates = Stream.of(
+                    getQueryPredicates(builder, root, finalText, ACCESS_LEVEL),
+                    getQueryPredicatesForJoin(builder, userPermissionJoin, finalText, ID, NAME))
+          .flatMap(Arrays::stream)
+          .toArray(Predicate[]::new);
+      return builder.or( predicates );
     };
   }
+
+  @SuppressWarnings("unchecked")
+  public static Specification<UserPermission> filterByUser(@NonNull List<SearchFilter> filters) {
+    return (root, query, builder) -> {
+      query.distinct(true);
+      Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
+      Join<UserPermission, User> userJoin = (Join<UserPermission, User>)userFetch;
+      return builder.and(
+          filters.stream()
+             .map(
+                  f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
+              .toArray(Predicate[]::new));
+    };
+  }
+
+  public static  Specification<UserPermission> buildFilterSpecification(@NonNull UUID policyId, @NonNull List<SearchFilter> filters){
+    return buildQueryAndFilterSpecification(policyId, filters,null);
+  }
+
+  public static Predicate filterByField(
+      @NonNull From from,
+      @NonNull CriteriaBuilder builder,
+      @NonNull String fieldName,
+      String fieldValue) {
+    val finalText = QueryUtils.prepareForQuery(fieldValue);
+
+    // Cast "as" String so that we can search ENUM types
+    return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
+  }
+  public static Collection<Predicate> buildFilterPredicates(From from, CriteriaBuilder builder, List<SearchFilter> filters ){
+    return filters.stream()
+        .map( f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
+        .collect(toUnmodifiableList());
+  }
+
+  public static Predicate buildIdEqualPredicate(From from, CriteriaBuilder builder, UUID id){
+    return builder.equal(from.<Integer>get(ID), id);
+  }
+
+  public static Stream<Predicate> streamQueryPredicates(From from, CriteriaBuilder builder, String text, String ... fieldNames){
+    val finalText = QueryUtils.prepareForQuery(text);
+    return Arrays.stream(fieldNames)
+        .map(fieldName -> builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText));
+  }
+  public static  Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(@NonNull UUID policyId,
+      @NonNull List<SearchFilter> filters, String text){
+    return (root, query, builder) -> {
+      query.distinct(true);
+      val policyJoin = leftJoinFetch(root, Policy.class, POLICY);
+      val userJoin = leftJoinFetch(root, User.class, OWNER);
+      val filterPredicates = Lists.<Predicate>newArrayList();
+      filterPredicates.addAll(buildFilterPredicates(userJoin, builder, filters));
+      filterPredicates.add(buildIdEqualPredicate(policyJoin,builder, policyId));
+      val andPredicate = builder.and(filterPredicates.toArray(Predicate[]::new));
+      val queryPredicates = Lists.<Predicate>newArrayList();
+      if (!isNullOrEmpty(text)){
+        val finalText = QueryUtils.prepareForQuery(text);
+        queryPredicates.add(builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
+        Stream.of(ID,NAME)
+            .map(fieldName -> builder.like(builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
+            .forEach(queryPredicates::add);
+        val orPredicate = builder.or(queryPredicates.toArray(Predicate[]::new));
+        return builder.and(andPredicate, orPredicate);
+      }
+      return builder.and(andPredicate);
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <X,Y> Join<X,Y> leftJoinFetch(From<X,X> root, Class<Y> joinClass, String joinField){
+    Fetch<X, Y> fetch= root.fetch(joinField, LEFT);
+    return (Join<X, Y>) fetch;
+  }
+
+  public static  Specification<UserPermission> buildQueryAndFilterSpecification(@NonNull UUID policyId,
+      @NonNull List<SearchFilter> filters, String text){
+    return (root, query, builder) -> {
+      query.distinct(true);
+      // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+      // Calling fetch followed by a join results in redundant join sql statements.
+      Fetch<UserPermission, Policy> userPermissionPolicyFetch= root.fetch(POLICY, LEFT);
+      Join<UserPermission, Policy> userPermissionPolicyJoin = (Join<UserPermission, Policy>) userPermissionPolicyFetch;
+      val andPredicates = Lists.<Predicate>newArrayList();
+      andPredicates.add(builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId));
+
+      Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
+      Join<UserPermission, User> userJoin = (Join<UserPermission, User>)userFetch;
+      filters.stream()
+          .map( f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
+          .forEach(andPredicates::add);
+      val orQueryPredicates = Lists.<Predicate>newArrayList();
+      if (!isNullOrEmpty(text)){
+        val finalText = QueryUtils.prepareForQuery(text);
+        orQueryPredicates.add(builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
+        Stream.of(ID,NAME)
+            .map(fieldName -> builder.like(builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
+            .forEach(orQueryPredicates::add);
+      }
+      val queryPredicate = builder.or(orQueryPredicates.toArray(Predicate[]::new));
+      val filterPredicate = builder.and(andPredicates.toArray(Predicate[]::new));
+      return builder.and(filterPredicate, queryPredicate);
+    };
+
+
+  }
+
 }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
@@ -18,31 +18,36 @@ package bio.overture.ego.repository.queryspecification;
 
 import static bio.overture.ego.model.enums.JavaFields.*;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Streams.concat;
-import static java.util.Arrays.stream;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static javax.persistence.criteria.JoinType.LEFT;
+import static lombok.AccessLevel.PRIVATE;
 
 import bio.overture.ego.model.entity.*;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.utils.QueryUtils;
-
+import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Fetch;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 
-import com.google.common.collect.Lists;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.springframework.data.jpa.domain.Specification;
 
 @Slf4j
@@ -53,10 +58,12 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
     return (root, query, builder) -> {
       query.distinct(true);
 
-      // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+      // [rtisma] Vlad said to do this:
+      // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
       // Calling fetch followed by a join results in redundant join sql statements.
-      Fetch<UserPermission, Policy> userPermissionPolicyFetch= root.fetch(POLICY, LEFT);
-      Join<UserPermission, Policy> userPermissionPolicyJoin = (Join<UserPermission, Policy>) userPermissionPolicyFetch;
+      Fetch<UserPermission, Policy> userPermissionPolicyFetch = root.fetch(POLICY, LEFT);
+      Join<UserPermission, Policy> userPermissionPolicyJoin =
+          (Join<UserPermission, Policy>) userPermissionPolicyFetch;
       return builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId);
     };
   }
@@ -65,19 +72,22 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
   public static Specification<UserPermission> containsText(@NonNull String text) {
     val finalText = QueryUtils.prepareForQuery(text);
 
-    // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+    // [rtisma] Vlad said to do this:
+    // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
     return (root, query, builder) -> {
-//      Fetch<UserPermission, User> userPermissionFetch = root.fetch(OWNER, LEFT);
-//      Join<UserPermission, User> userPermissionJoin = (Join<UserPermission, User>) userPermissionFetch;
-      Join<UserPermission, User> userPermissionJoin = root.join(OWNER,LEFT);
+      //      Fetch<UserPermission, User> userPermissionFetch = root.fetch(OWNER, LEFT);
+      //      Join<UserPermission, User> userPermissionJoin = (Join<UserPermission, User>)
+      // userPermissionFetch;
+      Join<UserPermission, User> userPermissionJoin = root.join(OWNER, LEFT);
 
       query.distinct(true);
-      val predicates = Stream.of(
-                    getQueryPredicates(builder, root, finalText, ACCESS_LEVEL),
-                    getQueryPredicatesForJoin(builder, userPermissionJoin, finalText, ID, NAME))
-          .flatMap(Arrays::stream)
-          .toArray(Predicate[]::new);
-      return builder.or( predicates );
+      val predicates =
+          Stream.of(
+                  getQueryPredicates(builder, root, finalText, ACCESS_LEVEL),
+                  getQueryPredicatesForJoin(builder, userPermissionJoin, finalText, ID, NAME))
+              .flatMap(Arrays::stream)
+              .toArray(Predicate[]::new);
+      return builder.or(predicates);
     };
   }
 
@@ -86,17 +96,20 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
     return (root, query, builder) -> {
       query.distinct(true);
       Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
-      Join<UserPermission, User> userJoin = (Join<UserPermission, User>)userFetch;
+      Join<UserPermission, User> userJoin = (Join<UserPermission, User>) userFetch;
       return builder.and(
           filters.stream()
-             .map(
-                  f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
+              .map(
+                  f ->
+                      filterByFieldForJoin(
+                          builder, userJoin, f.getFilterField(), f.getFilterValue()))
               .toArray(Predicate[]::new));
     };
   }
 
-  public static  Specification<UserPermission> buildFilterSpecification(@NonNull UUID policyId, @NonNull List<SearchFilter> filters){
-    return buildQueryAndFilterSpecification(policyId, filters,null);
+  public static Specification<UserPermission> buildFilterSpecification(
+      @NonNull UUID policyId, @NonNull List<SearchFilter> filters) {
+    return buildQueryAndFilterSpecification(policyId, filters, null);
   }
 
   public static Predicate filterByField(
@@ -109,37 +122,137 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
     // Cast "as" String so that we can search ENUM types
     return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
   }
-  public static Collection<Predicate> buildFilterPredicates(From from, CriteriaBuilder builder, List<SearchFilter> filters ){
+
+  public static Collection<Predicate> buildFilterPredicates(
+      From from, CriteriaBuilder builder, List<SearchFilter> filters) {
     return filters.stream()
-        .map( f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
+        .map(f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
         .collect(toUnmodifiableList());
   }
 
-  public static Predicate buildIdEqualPredicate(From from, CriteriaBuilder builder, UUID id){
+  public static Predicate buildIdEqualPredicate(From from, CriteriaBuilder builder, UUID id) {
     return builder.equal(from.<Integer>get(ID), id);
   }
 
-  public static Stream<Predicate> streamQueryPredicates(From from, CriteriaBuilder builder, String text, String ... fieldNames){
+  public static Stream<Predicate> streamQueryPredicates(
+      From from, CriteriaBuilder builder, String text, String... fieldNames) {
     val finalText = QueryUtils.prepareForQuery(text);
     return Arrays.stream(fieldNames)
-        .map(fieldName -> builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText));
+        .map(
+            fieldName ->
+                builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText));
   }
-  public static  Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(@NonNull UUID policyId,
-      @NonNull List<SearchFilter> filters, String text){
+
+  public static Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(
+      @NonNull UUID policyId, @NonNull List<SearchFilter> filters) {
+    return buildQueryAndFilterSpecification_BETTER(policyId, filters, null);
+  }
+
+  @RequiredArgsConstructor(access = PRIVATE)
+  public static class Sp<X,Y>{
+    @NonNull private final From<X,Y> from;
+    @NonNull private final CriteriaBuilder builder;
+    @NonNull private final CriteriaQuery<?> query;
+    public static <X,Y> Sp<X,Y> of(From<X,Y> from, CriteriaBuilder builder, CriteriaQuery<?> query){
+      return new Sp<>(from, builder, query);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> Sp<Y, T> leftJoinFetch(
+        Class<T> joinClass, String joinField) {
+      Fetch<Y, T> fetch = from.fetch(joinField, LEFT);
+      val join = (Join<Y, T>) fetch;
+      return new Sp<>(join, builder, query);
+    }
+
+    public void setDistinct(boolean distinct){
+      query.distinct(distinct);
+    }
+
+    public Predicate and(Predicate ... andPredicates){
+      return builder.and(andPredicates);
+    }
+
+    public Predicate or(Predicate ... orPredicates){
+      return builder.or(orPredicates);
+    }
+
+    public Collection<Predicate> searchFilter(@NonNull List<SearchFilter> filters) {
+      return filters.stream()
+          .map(f -> filterByField(f.getFilterField(), f.getFilterValue()))
+          .collect(toUnmodifiableList());
+    }
+
+    public Predicate filterByField( @NonNull String fieldName, String fieldValue) {
+      val finalText = QueryUtils.prepareForQuery(fieldValue);
+
+      // Cast "as" String so that we can search ENUM types
+      return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
+    }
+
+    public <T> Predicate matchField(@NonNull String fieldName, @NonNull T fieldValue ) {
+      return builder.equal(from.<T>get(fieldName), fieldValue);
+    }
+
+    public Predicate equalId(@NonNull UUID id) {
+      return builder.equal(from.<Integer>get(ID), id);
+    }
+
+  }
+
+  public static class SpecificationUtils{
+
+    @SuppressWarnings("unchecked")
+    private static <X, Y> Join<X, Y> leftJoinFetch(
+        From<X, X> root, Class<Y> joinClass, String joinField) {
+      Fetch<X, Y> fetch = root.fetch(joinField, LEFT);
+      return (Join<X, Y>) fetch;
+    }
+
+    public static <X,Y> Collection<Predicate> buildFilterPredicates(
+        From<X,Y> from, CriteriaBuilder builder, List<SearchFilter> filters) {
+      return filters.stream()
+          .map(f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
+          .collect(toUnmodifiableList());
+    }
+
+    public static <X,Y> Predicate filterByField(
+        @NonNull From<X,Y> from,
+        @NonNull CriteriaBuilder builder,
+        @NonNull String fieldName,
+        String fieldValue) {
+      val finalText = QueryUtils.prepareForQuery(fieldValue);
+
+      // Cast "as" String so that we can search ENUM types
+      return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
+    }
+
+    public static <X,Y, T> Predicate matchField(From<X,Y> from, CriteriaBuilder builder, String fieldName, T fieldValue ) {
+      return builder.equal(from.<T>get(fieldName), fieldValue);
+    }
+
+  }
+
+  public static Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(
+      @NonNull UUID policyId, @NonNull List<SearchFilter> filters, String text) {
     return (root, query, builder) -> {
       query.distinct(true);
       val policyJoin = leftJoinFetch(root, Policy.class, POLICY);
       val userJoin = leftJoinFetch(root, User.class, OWNER);
       val filterPredicates = Lists.<Predicate>newArrayList();
       filterPredicates.addAll(buildFilterPredicates(userJoin, builder, filters));
-      filterPredicates.add(buildIdEqualPredicate(policyJoin,builder, policyId));
+      filterPredicates.add(buildIdEqualPredicate(policyJoin, builder, policyId));
       val andPredicate = builder.and(filterPredicates.toArray(Predicate[]::new));
       val queryPredicates = Lists.<Predicate>newArrayList();
-      if (!isNullOrEmpty(text)){
+      if (!isNullOrEmpty(text)) {
         val finalText = QueryUtils.prepareForQuery(text);
-        queryPredicates.add(builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
-        Stream.of(ID,NAME)
-            .map(fieldName -> builder.like(builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
+        queryPredicates.add(
+            builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
+        Stream.of(ID, NAME)
+            .map(
+                fieldName ->
+                    builder.like(
+                        builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
             .forEach(queryPredicates::add);
         val orPredicate = builder.or(queryPredicates.toArray(Predicate[]::new));
         return builder.and(andPredicate, orPredicate);
@@ -149,39 +262,55 @@ public class UserPermissionSpecification extends SpecificationBase<UserPermissio
   }
 
   @SuppressWarnings("unchecked")
-  private static <X,Y> Join<X,Y> leftJoinFetch(From<X,X> root, Class<Y> joinClass, String joinField){
-    Fetch<X, Y> fetch= root.fetch(joinField, LEFT);
+  private static <X, Y> Join<X, Y> leftJoinFetch(
+      From<X, X> root, Class<Y> joinClass, String joinField) {
+    Fetch<X, Y> fetch = root.fetch(joinField, LEFT);
     return (Join<X, Y>) fetch;
   }
 
-  public static  Specification<UserPermission> buildQueryAndFilterSpecification(@NonNull UUID policyId,
-      @NonNull List<SearchFilter> filters, String text){
+  public static Specification<UserPermission> buildQueryAndFilterSpecification(
+      @NonNull UUID policyId, @NonNull List<SearchFilter> filters, String text) {
     return (root, query, builder) -> {
       query.distinct(true);
-      // [rtisma] Vlad said to do this:  https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
+      // [rtisma] Vlad said to do this:
+      // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
       // Calling fetch followed by a join results in redundant join sql statements.
-      Fetch<UserPermission, Policy> userPermissionPolicyFetch= root.fetch(POLICY, LEFT);
-      Join<UserPermission, Policy> userPermissionPolicyJoin = (Join<UserPermission, Policy>) userPermissionPolicyFetch;
+      Fetch<UserPermission, Policy> userPermissionPolicyFetch = root.fetch(POLICY, LEFT);
+      Join<UserPermission, Policy> userPermissionPolicyJoin =
+          (Join<UserPermission, Policy>) userPermissionPolicyFetch;
       val andPredicates = Lists.<Predicate>newArrayList();
       andPredicates.add(builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId));
 
       Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
-      Join<UserPermission, User> userJoin = (Join<UserPermission, User>)userFetch;
+      Join<UserPermission, User> userJoin = (Join<UserPermission, User>) userFetch;
       filters.stream()
-          .map( f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
+          .map(f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
           .forEach(andPredicates::add);
       val orQueryPredicates = Lists.<Predicate>newArrayList();
-      if (!isNullOrEmpty(text)){
+      if (!isNullOrEmpty(text)) {
         val finalText = QueryUtils.prepareForQuery(text);
-        orQueryPredicates.add(builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
-        Stream.of(ID,NAME)
-            .map(fieldName -> builder.like(builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
+        orQueryPredicates.add(
+            builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
+        Stream.of(ID, NAME)
+            .map(
+                fieldName ->
+                    builder.like(
+                        builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
             .forEach(orQueryPredicates::add);
       }
       val queryPredicate = builder.or(orQueryPredicates.toArray(Predicate[]::new));
       val filterPredicate = builder.and(andPredicates.toArray(Predicate[]::new));
       return builder.and(filterPredicate, queryPredicate);
     };
+  }
+
+  public static void sdf(){
+    val spUP = Sp.of((From<UserPermission,UserPermission>)null, null, null);
+    val spUser = spUP.leftJoinFetch(User.class, OWNER);
+    val spPolicy = spUP.leftJoinFetch(Policy.class, POLICY);
+
+    spPolicy.
+
 
 
   }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserPermissionSpecification.java
@@ -16,303 +16,70 @@
 
 package bio.overture.ego.repository.queryspecification;
 
-import static bio.overture.ego.model.enums.JavaFields.*;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toUnmodifiableList;
-import static javax.persistence.criteria.JoinType.LEFT;
-import static lombok.AccessLevel.PRIVATE;
-
-import bio.overture.ego.model.entity.*;
+import bio.overture.ego.model.entity.Policy;
+import bio.overture.ego.model.entity.User;
+import bio.overture.ego.model.entity.UserPermission;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.utils.QueryUtils;
 import com.google.common.collect.Lists;
-import java.util.Arrays;
-import java.util.Collection;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.Predicate;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Fetch;
-import javax.persistence.criteria.From;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.Predicate;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
-import org.springframework.data.jpa.domain.Specification;
+import static bio.overture.ego.model.enums.JavaFields.ACCESS_LEVEL;
+import static bio.overture.ego.model.enums.JavaFields.ID;
+import static bio.overture.ego.model.enums.JavaFields.NAME;
+import static bio.overture.ego.model.enums.JavaFields.OWNER;
+import static bio.overture.ego.model.enums.JavaFields.POLICY;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 @Slf4j
 public class UserPermissionSpecification extends SpecificationBase<UserPermission> {
 
-  @SuppressWarnings("unchecked")
-  public static Specification<UserPermission> withPolicy(@NonNull UUID policyId) {
-    return (root, query, builder) -> {
-      query.distinct(true);
-
-      // [rtisma] Vlad said to do this:
-      // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
-      // Calling fetch followed by a join results in redundant join sql statements.
-      Fetch<UserPermission, Policy> userPermissionPolicyFetch = root.fetch(POLICY, LEFT);
-      Join<UserPermission, Policy> userPermissionPolicyJoin =
-          (Join<UserPermission, Policy>) userPermissionPolicyFetch;
-      return builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId);
-    };
-  }
-
-  @SuppressWarnings("unchecked")
-  public static Specification<UserPermission> containsText(@NonNull String text) {
-    val finalText = QueryUtils.prepareForQuery(text);
-
-    // [rtisma] Vlad said to do this:
-    // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
-    return (root, query, builder) -> {
-      //      Fetch<UserPermission, User> userPermissionFetch = root.fetch(OWNER, LEFT);
-      //      Join<UserPermission, User> userPermissionJoin = (Join<UserPermission, User>)
-      // userPermissionFetch;
-      Join<UserPermission, User> userPermissionJoin = root.join(OWNER, LEFT);
-
-      query.distinct(true);
-      val predicates =
-          Stream.of(
-                  getQueryPredicates(builder, root, finalText, ACCESS_LEVEL),
-                  getQueryPredicatesForJoin(builder, userPermissionJoin, finalText, ID, NAME))
-              .flatMap(Arrays::stream)
-              .toArray(Predicate[]::new);
-      return builder.or(predicates);
-    };
-  }
-
-  @SuppressWarnings("unchecked")
-  public static Specification<UserPermission> filterByUser(@NonNull List<SearchFilter> filters) {
-    return (root, query, builder) -> {
-      query.distinct(true);
-      Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
-      Join<UserPermission, User> userJoin = (Join<UserPermission, User>) userFetch;
-      return builder.and(
-          filters.stream()
-              .map(
-                  f ->
-                      filterByFieldForJoin(
-                          builder, userJoin, f.getFilterField(), f.getFilterValue()))
-              .toArray(Predicate[]::new));
-    };
-  }
-
   public static Specification<UserPermission> buildFilterSpecification(
       @NonNull UUID policyId, @NonNull List<SearchFilter> filters) {
-    return buildQueryAndFilterSpecification(policyId, filters, null);
+    return buildFilterAndQuerySpecification(policyId, filters, null);
   }
 
-  public static Predicate filterByField(
-      @NonNull From from,
-      @NonNull CriteriaBuilder builder,
-      @NonNull String fieldName,
-      String fieldValue) {
-    val finalText = QueryUtils.prepareForQuery(fieldValue);
-
-    // Cast "as" String so that we can search ENUM types
-    return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
-  }
-
-  public static Collection<Predicate> buildFilterPredicates(
-      From from, CriteriaBuilder builder, List<SearchFilter> filters) {
-    return filters.stream()
-        .map(f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
-        .collect(toUnmodifiableList());
-  }
-
-  public static Predicate buildIdEqualPredicate(From from, CriteriaBuilder builder, UUID id) {
-    return builder.equal(from.<Integer>get(ID), id);
-  }
-
-  public static Stream<Predicate> streamQueryPredicates(
-      From from, CriteriaBuilder builder, String text, String... fieldNames) {
-    val finalText = QueryUtils.prepareForQuery(text);
-    return Arrays.stream(fieldNames)
-        .map(
-            fieldName ->
-                builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText));
-  }
-
-  public static Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(
-      @NonNull UUID policyId, @NonNull List<SearchFilter> filters) {
-    return buildQueryAndFilterSpecification_BETTER(policyId, filters, null);
-  }
-
-  @RequiredArgsConstructor(access = PRIVATE)
-  public static class Sp<X,Y>{
-    @NonNull private final From<X,Y> from;
-    @NonNull private final CriteriaBuilder builder;
-    @NonNull private final CriteriaQuery<?> query;
-    public static <X,Y> Sp<X,Y> of(From<X,Y> from, CriteriaBuilder builder, CriteriaQuery<?> query){
-      return new Sp<>(from, builder, query);
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Sp<Y, T> leftJoinFetch(
-        Class<T> joinClass, String joinField) {
-      Fetch<Y, T> fetch = from.fetch(joinField, LEFT);
-      val join = (Join<Y, T>) fetch;
-      return new Sp<>(join, builder, query);
-    }
-
-    public void setDistinct(boolean distinct){
-      query.distinct(distinct);
-    }
-
-    public Predicate and(Predicate ... andPredicates){
-      return builder.and(andPredicates);
-    }
-
-    public Predicate or(Predicate ... orPredicates){
-      return builder.or(orPredicates);
-    }
-
-    public Collection<Predicate> searchFilter(@NonNull List<SearchFilter> filters) {
-      return filters.stream()
-          .map(f -> filterByField(f.getFilterField(), f.getFilterValue()))
-          .collect(toUnmodifiableList());
-    }
-
-    public Predicate filterByField( @NonNull String fieldName, String fieldValue) {
-      val finalText = QueryUtils.prepareForQuery(fieldValue);
-
-      // Cast "as" String so that we can search ENUM types
-      return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
-    }
-
-    public <T> Predicate matchField(@NonNull String fieldName, @NonNull T fieldValue ) {
-      return builder.equal(from.<T>get(fieldName), fieldValue);
-    }
-
-    public Predicate equalId(@NonNull UUID id) {
-      return builder.equal(from.<Integer>get(ID), id);
-    }
-
-  }
-
-  public static class SpecificationUtils{
-
-    @SuppressWarnings("unchecked")
-    private static <X, Y> Join<X, Y> leftJoinFetch(
-        From<X, X> root, Class<Y> joinClass, String joinField) {
-      Fetch<X, Y> fetch = root.fetch(joinField, LEFT);
-      return (Join<X, Y>) fetch;
-    }
-
-    public static <X,Y> Collection<Predicate> buildFilterPredicates(
-        From<X,Y> from, CriteriaBuilder builder, List<SearchFilter> filters) {
-      return filters.stream()
-          .map(f -> filterByField(from, builder, f.getFilterField(), f.getFilterValue()))
-          .collect(toUnmodifiableList());
-    }
-
-    public static <X,Y> Predicate filterByField(
-        @NonNull From<X,Y> from,
-        @NonNull CriteriaBuilder builder,
-        @NonNull String fieldName,
-        String fieldValue) {
-      val finalText = QueryUtils.prepareForQuery(fieldValue);
-
-      // Cast "as" String so that we can search ENUM types
-      return builder.like(builder.lower(from.get(fieldName).as(String.class)), finalText);
-    }
-
-    public static <X,Y, T> Predicate matchField(From<X,Y> from, CriteriaBuilder builder, String fieldName, T fieldValue ) {
-      return builder.equal(from.<T>get(fieldName), fieldValue);
-    }
-
-  }
-
-  public static Specification<UserPermission> buildQueryAndFilterSpecification_BETTER(
+  public static Specification<UserPermission> buildFilterAndQuerySpecification(
       @NonNull UUID policyId, @NonNull List<SearchFilter> filters, String text) {
     return (root, query, builder) -> {
-      query.distinct(true);
-      val policyJoin = leftJoinFetch(root, Policy.class, POLICY);
-      val userJoin = leftJoinFetch(root, User.class, OWNER);
-      val filterPredicates = Lists.<Predicate>newArrayList();
-      filterPredicates.addAll(buildFilterPredicates(userJoin, builder, filters));
-      filterPredicates.add(buildIdEqualPredicate(policyJoin, builder, policyId));
-      val andPredicate = builder.and(filterPredicates.toArray(Predicate[]::new));
-      val queryPredicates = Lists.<Predicate>newArrayList();
+      val sp = SimpleCriteriaBuilder.of(root, builder, query);
+      sp.setDistinct(true);
+      // Create joins
+      val policySp = sp.leftJoinFetch(Policy.class, POLICY);
+      val userSp = sp.leftJoinFetch(User.class, OWNER);
+
+      // Create predicates for filtering by policyId AND searchFilters
+      val filterPredicates = userSp.searchFilter(filters);
+      val policyIdPredicate = policySp.equalId(policyId);
+      val andPredicates= Lists.<Predicate>newArrayList();
+      andPredicates.addAll(filterPredicates);
+      andPredicates.add(policyIdPredicate);
+      val andPredicate = builder.and(andPredicates.toArray(Predicate[]::new));
+
       if (!isNullOrEmpty(text)) {
+        // Create query predicate
+        val queryPredicates = Lists.<Predicate>newArrayList();
         val finalText = QueryUtils.prepareForQuery(text);
         queryPredicates.add(
             builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
         Stream.of(ID, NAME)
-            .map(
-                fieldName ->
-                    builder.like(
-                        builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
+            .map( fieldName -> userSp.matchStringField(fieldName, finalText))
             .forEach(queryPredicates::add);
+        // Query predicates should be ORed together
         val orPredicate = builder.or(queryPredicates.toArray(Predicate[]::new));
+
+        // Query and Filter predicate should be ANDed
         return builder.and(andPredicate, orPredicate);
       }
-      return builder.and(andPredicate);
+      return andPredicate;
     };
   }
-
-  @SuppressWarnings("unchecked")
-  private static <X, Y> Join<X, Y> leftJoinFetch(
-      From<X, X> root, Class<Y> joinClass, String joinField) {
-    Fetch<X, Y> fetch = root.fetch(joinField, LEFT);
-    return (Join<X, Y>) fetch;
-  }
-
-  public static Specification<UserPermission> buildQueryAndFilterSpecification(
-      @NonNull UUID policyId, @NonNull List<SearchFilter> filters, String text) {
-    return (root, query, builder) -> {
-      query.distinct(true);
-      // [rtisma] Vlad said to do this:
-      // https://discourse.hibernate.org/t/how-can-i-do-a-join-fetch-in-criteria-api/846/6
-      // Calling fetch followed by a join results in redundant join sql statements.
-      Fetch<UserPermission, Policy> userPermissionPolicyFetch = root.fetch(POLICY, LEFT);
-      Join<UserPermission, Policy> userPermissionPolicyJoin =
-          (Join<UserPermission, Policy>) userPermissionPolicyFetch;
-      val andPredicates = Lists.<Predicate>newArrayList();
-      andPredicates.add(builder.equal(userPermissionPolicyJoin.<Integer>get(ID), policyId));
-
-      Fetch<UserPermission, User> userFetch = root.fetch(OWNER, LEFT);
-      Join<UserPermission, User> userJoin = (Join<UserPermission, User>) userFetch;
-      filters.stream()
-          .map(f -> filterByFieldForJoin(builder, userJoin, f.getFilterField(), f.getFilterValue()))
-          .forEach(andPredicates::add);
-      val orQueryPredicates = Lists.<Predicate>newArrayList();
-      if (!isNullOrEmpty(text)) {
-        val finalText = QueryUtils.prepareForQuery(text);
-        orQueryPredicates.add(
-            builder.like(builder.lower(root.get(ACCESS_LEVEL).as(String.class)), finalText));
-        Stream.of(ID, NAME)
-            .map(
-                fieldName ->
-                    builder.like(
-                        builder.lower(userJoin.get(fieldName).as(String.class)), finalText))
-            .forEach(orQueryPredicates::add);
-      }
-      val queryPredicate = builder.or(orQueryPredicates.toArray(Predicate[]::new));
-      val filterPredicate = builder.and(andPredicates.toArray(Predicate[]::new));
-      return builder.and(filterPredicate, queryPredicate);
-    };
-  }
-
-  public static void sdf(){
-    val spUP = Sp.of((From<UserPermission,UserPermission>)null, null, null);
-    val spUser = spUP.leftJoinFetch(User.class, OWNER);
-    val spPolicy = spUP.leftJoinFetch(Policy.class, POLICY);
-
-    spPolicy.
-
-
-
-  }
-
 }

--- a/src/main/java/bio/overture/ego/service/AbstractPermissionService.java
+++ b/src/main/java/bio/overture/ego/service/AbstractPermissionService.java
@@ -34,7 +34,6 @@ import bio.overture.ego.model.entity.Policy;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.PermissionRepository;
 import bio.overture.ego.repository.queryspecification.GroupPermissionSpecification;
-import bio.overture.ego.repository.queryspecification.UserPermissionSpecification;
 import bio.overture.ego.utils.PermissionRequestAnalyzer.PermissionAnalysis;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
@@ -95,46 +94,6 @@ public abstract class AbstractPermissionService<
   public List<PolicyResponse> findByPolicy(UUID policyId) {
     val permissions = ImmutableList.copyOf(permissionRepository.findAllByPolicy_Id(policyId));
     return mapToList(permissions, this::convertToPolicyResponse);
-  }
-
-  public Page<PolicyResponse> listUserPermissionsByPolicy(
-      @NonNull UUID policyId, List<SearchFilter> filters, @NonNull Pageable pageable) {
-    val userPermissions =
-        (Page<P>)
-            getRepository()
-                .findAll(
-                    where(UserPermissionSpecification.withPolicy(policyId))
-                        .and(UserPermissionSpecification.filterBy(filters)),
-                    pageable);
-
-    val responses =
-        ImmutableList.copyOf(userPermissions).stream()
-            .map(this::convertToPolicyResponse)
-            .collect(java.util.stream.Collectors.toList());
-
-    return new PageImpl<>(responses, pageable, userPermissions.getTotalElements());
-  }
-
-  public Page<PolicyResponse> findUserPermissionsByPolicy(
-      @NonNull UUID policyId,
-      List<SearchFilter> filters,
-      String query,
-      @NonNull Pageable pageable) {
-    val userPermissions =
-        (Page<P>)
-            getRepository()
-                .findAll(
-                    where(UserPermissionSpecification.withPolicy(policyId))
-                        .and(UserPermissionSpecification.containsText(query))
-                        .and(UserPermissionSpecification.filterBy(filters)),
-                    pageable);
-
-    val responses =
-        ImmutableList.copyOf(userPermissions).stream()
-            .map(this::convertToPolicyResponse)
-            .collect(java.util.stream.Collectors.toList());
-
-    return new PageImpl<>(responses, pageable, userPermissions.getTotalElements());
   }
 
   public Page<PolicyResponse> listGroupPermissionsByPolicy(
@@ -402,7 +361,7 @@ public abstract class AbstractPermissionService<
     return permissions.get(0);
   }
 
-  private PolicyResponse convertToPolicyResponse(@NonNull P p) {
+  protected PolicyResponse convertToPolicyResponse(@NonNull P p) {
     val name = p.getOwner().getName();
     val id = p.getOwner().getId().toString();
     val mask = p.getAccessLevel();

--- a/src/main/java/bio/overture/ego/service/UserPermissionService.java
+++ b/src/main/java/bio/overture/ego/service/UserPermissionService.java
@@ -1,7 +1,6 @@
 package bio.overture.ego.service;
 
 import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildFilterSpecification;
-import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildQueryAndFilterSpecification;
 import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildQueryAndFilterSpecification_BETTER;
 import static bio.overture.ego.utils.CollectionUtils.mapToList;
 import static java.util.stream.Collectors.toUnmodifiableList;
@@ -15,7 +14,6 @@ import bio.overture.ego.model.entity.*;
 import bio.overture.ego.model.join.UserGroup;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.UserPermissionRepository;
-import bio.overture.ego.repository.queryspecification.UserPermissionSpecification;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
@@ -27,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,8 +53,7 @@ public class UserPermissionService extends AbstractPermissionService<User, UserP
       @NonNull UUID policyId, List<SearchFilter> filters, @NonNull Pageable pageable) {
     val userPermissions =
         (Page<UserPermission>)
-            getRepository()
-                .findAll( buildFilterSpecification(policyId, filters), pageable);
+            getRepository().findAll(buildQueryAndFilterSpecification_BETTER(policyId, filters), pageable);
 
     val responses =
         ImmutableList.copyOf(userPermissions).stream()
@@ -72,12 +68,14 @@ public class UserPermissionService extends AbstractPermissionService<User, UserP
       List<SearchFilter> filters,
       String query,
       @NonNull Pageable pageable) {
-    // Since userPermissions needs users and policies fetched, cannot just do a join, need to do a fetch AND join,
+    // Since userPermissions needs users and policies fetched, cannot just do a join, need to do a
+    // fetch AND join,
     // otherwise will experience N+1 query problem
     val userPermissions =
         (Page<UserPermission>)
             getRepository()
-                .findAll( buildQueryAndFilterSpecification_BETTER(policyId, filters, query), pageable);
+                .findAll(
+                    buildQueryAndFilterSpecification_BETTER(policyId, filters, query), pageable);
 
     val responses =
         ImmutableList.copyOf(userPermissions).stream()

--- a/src/main/java/bio/overture/ego/service/UserPermissionService.java
+++ b/src/main/java/bio/overture/ego/service/UserPermissionService.java
@@ -1,16 +1,22 @@
 package bio.overture.ego.service;
 
-import static bio.overture.ego.service.AbstractPermissionService.resolveFinalPermissions;
+import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildFilterSpecification;
+import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildQueryAndFilterSpecification;
+import static bio.overture.ego.repository.queryspecification.UserPermissionSpecification.buildQueryAndFilterSpecification_BETTER;
 import static bio.overture.ego.utils.CollectionUtils.mapToList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import bio.overture.ego.event.token.ApiKeyEventsPublisher;
 import bio.overture.ego.model.dto.PermissionRequest;
+import bio.overture.ego.model.dto.PolicyResponse;
 import bio.overture.ego.model.dto.ResolvedPermissionResponse;
 import bio.overture.ego.model.entity.*;
 import bio.overture.ego.model.join.UserGroup;
+import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.UserPermissionRepository;
+import bio.overture.ego.repository.queryspecification.UserPermissionSpecification;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import java.util.List;
@@ -18,6 +24,10 @@ import java.util.UUID;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +50,41 @@ public class UserPermissionService extends AbstractPermissionService<User, UserP
     super(User.class, UserPermission.class, userService, policyService, repository);
     this.userService = userService;
     this.apiKeyEventsPublisher = apiKeyEventsPublisher;
+  }
+
+  public Page<PolicyResponse> listUserPermissionsByPolicy(
+      @NonNull UUID policyId, List<SearchFilter> filters, @NonNull Pageable pageable) {
+    val userPermissions =
+        (Page<UserPermission>)
+            getRepository()
+                .findAll( buildFilterSpecification(policyId, filters), pageable);
+
+    val responses =
+        ImmutableList.copyOf(userPermissions).stream()
+            .map(this::convertToPolicyResponse)
+            .collect(toUnmodifiableList());
+
+    return new PageImpl<>(responses, pageable, userPermissions.getTotalElements());
+  }
+
+  public Page<PolicyResponse> findUserPermissionsByPolicy(
+      @NonNull UUID policyId,
+      List<SearchFilter> filters,
+      String query,
+      @NonNull Pageable pageable) {
+    // Since userPermissions needs users and policies fetched, cannot just do a join, need to do a fetch AND join,
+    // otherwise will experience N+1 query problem
+    val userPermissions =
+        (Page<UserPermission>)
+            getRepository()
+                .findAll( buildQueryAndFilterSpecification_BETTER(policyId, filters, query), pageable);
+
+    val responses =
+        ImmutableList.copyOf(userPermissions).stream()
+            .map(this::convertToPolicyResponse)
+            .collect(toUnmodifiableList());
+
+    return new PageImpl<>(responses, pageable, userPermissions.getTotalElements());
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,9 +121,9 @@ logging:
     bio.overture.ego: INFO
 
 # Hibernate SQL Debugging
-spring.jpa.properties.hibernate.format_sql: true
-logging.level.org.hibernate.SQL: DEBUG
-logging.level.org.hibernate.type.descriptor.sql: TRACE
+#spring.jpa.properties.hibernate.format_sql: true
+#logging.level.org.hibernate.SQL: DEBUG
+#logging.level.org.hibernate.type.descriptor.sql: TRACE
 
 # When you are desperate, use this...
 #logging.level.org.hibernate: TRACE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,9 +121,9 @@ logging:
     bio.overture.ego: INFO
 
 # Hibernate SQL Debugging
-#spring.jpa.properties.hibernate.format_sql: true
-#logging.level.org.hibernate.SQL: DEBUG
-#logging.level.org.hibernate.type.descriptor.sql: TRACE
+spring.jpa.properties.hibernate.format_sql: true
+logging.level.org.hibernate.SQL: DEBUG
+logging.level.org.hibernate.type.descriptor.sql: TRACE
 
 # When you are desperate, use this...
 #logging.level.org.hibernate: TRACE

--- a/src/test/java/bio/overture/ego/controller/AbstractPermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/AbstractPermissionControllerTest.java
@@ -53,11 +53,11 @@ public abstract class AbstractPermissionControllerTest<
   private static final String INVALID_UUID = "invalidUUID000";
 
   /** State */
-  private O owner1;
+  protected O owner1;
 
-  private O owner2;
-  private List<Policy> policies;
-  private List<PermissionRequest> permissionRequests;
+  protected O owner2;
+  protected List<Policy> policies;
+  protected List<PermissionRequest> permissionRequests;
 
   @Override
   protected void beforeTest() {

--- a/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
@@ -135,6 +135,7 @@ public class UserPermissionControllerTest
     return format("policies/%s/users", policyId);
   }
 
+  //TODO: delete this test
   @Test
   @SneakyThrows
   public void addPermissionsToOwner_Unique_Success__ROB() {
@@ -170,7 +171,7 @@ public class UserPermissionControllerTest
     val p = this.policies.get(0);
     val resp =
         initStringRequest()
-            .endpoint("policies/%s/users?name=%s", p.getId(), owner1.getName())
+            .endpoint("policies/%s/users?query=%s", p.getId(), owner1.getName())
             .getAnd()
             .getResponse();
     log.info("response: {}", resp);

--- a/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
@@ -1,7 +1,14 @@
 package bio.overture.ego.controller;
 
+import static bio.overture.ego.model.enums.AccessLevel.DENY;
+import static bio.overture.ego.model.enums.AccessLevel.WRITE;
 import static bio.overture.ego.utils.Joiners.COMMA;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.http.HttpStatus.OK;
 
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.entity.User;
@@ -12,9 +19,13 @@ import bio.overture.ego.service.PolicyService;
 import bio.overture.ego.service.UserPermissionService;
 import bio.overture.ego.service.UserService;
 import bio.overture.ego.utils.EntityGenerator;
+import bio.overture.ego.utils.Streams;
 import java.util.Collection;
 import java.util.UUID;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -122,5 +133,46 @@ public class UserPermissionControllerTest
   @Override
   protected String getReadOwnersForPolicyEndpoint(String policyId) {
     return format("policies/%s/users", policyId);
+  }
+
+  @Test
+  @SneakyThrows
+  public void addPermissionsToOwner_Unique_Success__ROB() {
+    // Add Permissions to owner
+    val r1 =
+        initStringRequest()
+            .endpoint(getAddPermissionsEndpoint(owner1.getId().toString()))
+            .body(permissionRequests)
+            .post();
+    assertEquals(r1.getStatusCode(), OK);
+
+    // Get the policies for this owner
+    val r3 =
+        initStringRequest().endpoint(getReadPermissionsEndpoint(owner1.getId().toString())).get();
+    assertEquals(r3.getStatusCode(), OK);
+
+    // Analyze results
+    val page = MAPPER.readTree(r3.getBody());
+    assertNotNull(page);
+    assertEquals(page.get("count").asInt(), 2);
+    val outputMap =
+        Streams.stream(page.path("resultSet").iterator())
+            .collect(
+                toMap(
+                    x -> x.path("policy").path("id").asText(),
+                    x -> x.path("accessLevel").asText()));
+    assertTrue(outputMap.containsKey(policies.get(0).getId().toString()));
+    assertTrue(outputMap.containsKey(policies.get(1).getId().toString()));
+    assertEquals(outputMap.get(policies.get(0).getId().toString()), WRITE.toString());
+    assertEquals(outputMap.get(policies.get(1).getId().toString()), DENY.toString());
+
+    ////////////////////
+    val p = this.policies.get(0);
+    val resp =
+        initStringRequest()
+            .endpoint("policies/%s/users?query=%s", p.getId(), owner1.getName())
+            .getAnd()
+            .getResponse();
+    log.info("response: {}", resp);
   }
 }

--- a/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/UserPermissionControllerTest.java
@@ -170,7 +170,7 @@ public class UserPermissionControllerTest
     val p = this.policies.get(0);
     val resp =
         initStringRequest()
-            .endpoint("policies/%s/users?query=%s", p.getId(), owner1.getName())
+            .endpoint("policies/%s/users?name=%s", p.getId(), owner1.getName())
             .getAnd()
             .getResponse();
     log.info("response: {}", resp);


### PR DESCRIPTION
Query now correctly generates non-redundant joins, and is joining on the correct entities
Also added a generic SimpleCriteriaBuilder utility.

There is a test called `addPermissionsToOwner_Unique_Success__ROB`, that was used to trigger the find vs listing feature of /policies/{}/users

To inspect the SQL queries, uncomment the appropriate lines in the application.yml and run the above test