### PR TITLE
Provide Default Scope if none available

### DIFF
--- a/src/main/java/bio/overture/ego/model/dto/PolicyRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/PolicyRequest.java
@@ -1,6 +1,7 @@
 package bio.overture.ego.model.dto;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,5 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PolicyRequest {
 
-  @NotNull private String name;
+  @NotNull
+  @Pattern(regexp = "^[A-Za-z0-9_-]+$")
+  private String name;
 }

--- a/src/main/java/bio/overture/ego/model/dto/Scope.java
+++ b/src/main/java/bio/overture/ego/model/dto/Scope.java
@@ -120,4 +120,13 @@ public class Scope {
   public static Scope createScope(@NonNull Policy policy, @NonNull AccessLevel accessLevel) {
     return new Scope(policy, accessLevel);
   }
+
+  /**
+   * Provides a default scope with value *.DENY . This can be used when a JWT has received no scopes
+   * and a default value is required. This scope would indicate that the JWT provides no
+   * authorization.
+   */
+  public static Scope defaultScope() {
+    return createScope(Policy.builder().name("*").build(), AccessLevel.DENY);
+  }
 }

--- a/src/main/java/bio/overture/ego/model/entity/Policy.java
+++ b/src/main/java/bio/overture/ego/model/entity/Policy.java
@@ -23,6 +23,8 @@ import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -57,6 +59,7 @@ public class Policy implements Identifiable<UUID> {
   private UUID id;
 
   @NotNull
+  @Pattern(regexp = "^[A-Za-z0-9_-]+$")
   @Column(name = SqlFields.NAME, unique = true, nullable = false)
   private String name;
 

--- a/src/main/java/bio/overture/ego/service/UserService.java
+++ b/src/main/java/bio/overture/ego/service/UserService.java
@@ -455,7 +455,12 @@ public class UserService extends AbstractNamedService<User, UUID> {
   }
 
   public static Set<Scope> extractScopes(@NonNull User user) {
-    return mapToSet(resolveUsersPermissions(user), AbstractPermissionService::buildScope);
+    val resolvedPermissions = resolveUsersPermissions(user);
+    val output = mapToSet(resolvedPermissions, AbstractPermissionService::buildScope);
+    if (output.isEmpty()) {
+      output.add(Scope.defaultScope());
+    }
+    return output;
   }
 
   public static void disassociateUserApplicationsFromUser(

--- a/src/test/java/bio/overture/ego/controller/AbstractResolvablePermissionControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/AbstractResolvablePermissionControllerTest.java
@@ -27,9 +27,9 @@ public abstract class AbstractResolvablePermissionControllerTest<
     val group = getEntityGenerator().setupGroup(UUID.randomUUID().toString());
 
     // create policies
-    val readPolicy = getEntityGenerator().setupSinglePolicy("READ Policy");
-    val writePolicy = getEntityGenerator().setupSinglePolicy("WRITE Policy");
-    val denyPolicy = getEntityGenerator().setupSinglePolicy("DENY Policy");
+    val readPolicy = getEntityGenerator().setupSinglePolicy("READPolicy");
+    val writePolicy = getEntityGenerator().setupSinglePolicy("WRITEPolicy");
+    val denyPolicy = getEntityGenerator().setupSinglePolicy("DENYPolicy");
 
     // Add permissions to owner
     val r1 =
@@ -97,9 +97,9 @@ public abstract class AbstractResolvablePermissionControllerTest<
     val group3 = getEntityGenerator().setupGroup(UUID.randomUUID().toString());
 
     // create policies
-    val policy1 = getEntityGenerator().setupSinglePolicy("Policy 1");
-    val policy2 = getEntityGenerator().setupSinglePolicy("Policy 2");
-    val policy3 = getEntityGenerator().setupSinglePolicy("Policy 3");
+    val policy1 = getEntityGenerator().setupSinglePolicy("Policy1");
+    val policy2 = getEntityGenerator().setupSinglePolicy("Policy2");
+    val policy3 = getEntityGenerator().setupSinglePolicy("Policy3");
 
     val ownerId1 = owner1.getId().toString();
     val ownerId2 = owner2.getId().toString();

--- a/src/test/java/bio/overture/ego/controller/ApiKeyControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/ApiKeyControllerTest.java
@@ -79,7 +79,7 @@ public class ApiKeyControllerTest extends AbstractControllerTest {
     val user = entityGenerator.setupUser("Test User");
     val userId = user.getId();
     val standByUser = entityGenerator.setupUser("Test User2");
-    entityGenerator.setupPolicies("aws,no-be-used", "collab,no-be-used");
+    entityGenerator.setupPolicies("aws-no-be-used", "collab-no-be-used");
     entityGenerator.addPermissions(user, entityGenerator.getScopes("aws.READ", "collab.READ"));
 
     val apiKeyRevoke =

--- a/src/test/java/bio/overture/ego/controller/PolicyControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/PolicyControllerTest.java
@@ -21,8 +21,7 @@ import static bio.overture.ego.controller.AbstractPermissionControllerTest.creat
 import static bio.overture.ego.model.enums.AccessLevel.READ;
 import static bio.overture.ego.model.enums.AccessLevel.WRITE;
 import static org.junit.Assert.assertEquals;
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.dto.PolicyRequest;
@@ -89,6 +88,17 @@ public class PolicyControllerTest extends AbstractControllerTest {
     log.info(response.getBody());
 
     assertEquals(responseJson.get("name").asText(), "AddPolicy");
+  }
+
+  @Test
+  @SneakyThrows
+  public void addPolicy_invalidCharacter_badRequest() {
+    val policy = PolicyRequest.builder().name("AddPolicy!").build();
+
+    val response = initStringRequest().endpoint("/policies").body(policy).post();
+
+    val responseStatus = response.getStatusCode();
+    assertEquals(responseStatus, BAD_REQUEST);
   }
 
   @Test

--- a/src/test/java/bio/overture/ego/controller/PolicyControllerTest.java
+++ b/src/test/java/bio/overture/ego/controller/PolicyControllerTest.java
@@ -122,7 +122,7 @@ public class PolicyControllerTest extends AbstractControllerTest {
   }
 
   public void associatePermissionsWithEntity(NameableEntity entity, String entityName) {
-    val policyName = String.format("Add %s Permission", entityName);
+    val policyName = String.format("AddPermission_%s", entityName);
     val policyId = entityGenerator.setupSinglePolicy(policyName).getId().toString();
     val entityId = entity.getId().toString();
 
@@ -152,7 +152,7 @@ public class PolicyControllerTest extends AbstractControllerTest {
   }
 
   public void disassociatePermissionsFromEntity(NameableEntity entity, String entityName) {
-    val policyName = String.format("Delete %s Permission", entityName);
+    val policyName = String.format("DeletePermission_%s", entityName);
     val policyId = entityGenerator.setupSinglePolicy(policyName).getId().toString();
     val entityId = entity.getId().toString();
 
@@ -189,7 +189,7 @@ public class PolicyControllerTest extends AbstractControllerTest {
   @Test
   @SneakyThrows
   public void associatePermissionsWithGroup_ExistingEntitiesButNonExistingRelationship_Success() {
-    val testGroup = entityGenerator.setupGroup("GroupPolicyAdd");
+    val testGroup = entityGenerator.setupGroup("GroupPolicy Add");
     associatePermissionsWithEntity(testGroup, "group");
   }
 
@@ -217,14 +217,14 @@ public class PolicyControllerTest extends AbstractControllerTest {
   @Test
   @SneakyThrows
   public void associatePermissionsWithApplication_ExistingEntitiesButNoRelationship_Success() {
-    val testApp = entityGenerator.setupApplication("AppPolicy Add");
+    val testApp = entityGenerator.setupApplication("AppPolicyAdd");
     associatePermissionsWithEntity(testApp, "application");
   }
 
   @Test
   @SneakyThrows
   public void disassociatePermissionsFromApplication_ExistingEntitiesAndRelationships_Success() {
-    val testApp = entityGenerator.setupApplication("AppPolicy Delete");
+    val testApp = entityGenerator.setupApplication("AppPolicyDelete");
     disassociatePermissionsFromEntity(testApp, "application");
   }
 }

--- a/src/test/java/bio/overture/ego/controller/TokensOnPermissionsChangeTest.java
+++ b/src/test/java/bio/overture/ego/controller/TokensOnPermissionsChangeTest.java
@@ -175,7 +175,7 @@ public class TokensOnPermissionsChangeTest extends AbstractControllerTest {
   @SneakyThrows
   public void denyPermissionFromUser_ExistingToken_RevokeTokenSuccess() {
     val user = entityGenerator.setupUser("UserFoo DenyPermission");
-    val policy = entityGenerator.setupSinglePolicy("song.abc");
+    val policy = entityGenerator.setupSinglePolicy("songabc");
     val apiKey = userPermissionTestSetup(user, policy, AccessLevel.WRITE, "WRITE");
 
     val permissionDenyRequest =

--- a/src/test/java/bio/overture/ego/controller/UpdateTokenTest.java
+++ b/src/test/java/bio/overture/ego/controller/UpdateTokenTest.java
@@ -22,6 +22,7 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import bio.overture.ego.AuthorizationServiceMain;
 import bio.overture.ego.model.dto.PermissionRequest;
+import bio.overture.ego.model.dto.Scope;
 import bio.overture.ego.model.entity.Policy;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.enums.AccessLevel;
@@ -112,7 +113,6 @@ public class UpdateTokenTest extends AbstractControllerTest {
     val controlToken = tokenService.generateUserToken(user);
 
     val updatedToken = updateResponse.getBody();
-    log.debug(updatedToken);
 
     val firstTokenClaims = tokenService.validateAndReturn(firstToken).getBody();
     val updatedTokenClaims = tokenService.validateAndReturn(updatedToken).getBody();
@@ -132,7 +132,8 @@ public class UpdateTokenTest extends AbstractControllerTest {
     val firstContext = firstTokenClaims.get("context", LinkedHashMap.class);
     val updatedContext = updatedTokenClaims.get("context", LinkedHashMap.class);
 
-    assertTrue(((Collection) firstContext.get("scope")).isEmpty()); // No scopes originally
+    assertEquals(1, ((Collection) firstContext.get("scope")).size()); // No scopes originally means return default scope
+    assertTrue(((Collection) firstContext.get("scope")).contains(Scope.defaultScope().toString()));
     assertFalse(
         ((Collection) updatedContext.get("scope")).isEmpty()); // Has scopes in updated token
 


### PR DESCRIPTION
Also enforces Policy name characters to be {alphanumeric, _, -}

Required for 3.3.x to be deployed as this was blocking application authentication.