### PR TITLE
Different durations for app and user jwts.

### DIFF
--- a/src/main/java/bio/overture/ego/service/ApiKeyStoreService.java
+++ b/src/main/java/bio/overture/ego/service/ApiKeyStoreService.java
@@ -65,11 +65,11 @@ public class ApiKeyStoreService extends AbstractNamedService<ApiKey, UUID> {
     return result.get();
   }
 
+  @SuppressWarnings("unused")
   public ApiKey create(@NonNull CreateTokenRequest createTokenRequest) {
     throw new NotImplementedException();
   }
 
-  @Deprecated
   public ApiKey create(@NonNull ApiKey scopedAccessApiKey) {
     ApiKey res = tokenRepository.save(scopedAccessApiKey);
     tokenRepository.revokeRedundantTokens(scopedAccessApiKey.getOwner().getId());

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -26,6 +26,7 @@ import static bio.overture.ego.utils.EntityServices.checkEntityExistence;
 import static bio.overture.ego.utils.TypeUtils.convertToAnotherType;
 import static java.lang.String.format;
 import static java.util.UUID.fromString;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.springframework.data.jpa.domain.Specification.where;
 import static org.springframework.util.DigestUtils.md5Digest;
 
@@ -34,6 +35,8 @@ import bio.overture.ego.model.entity.ApiKey;
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.exceptions.ForbiddenException;
+import bio.overture.ego.model.exceptions.InternalServerException;
+import bio.overture.ego.model.exceptions.UnauthorizedException;
 import bio.overture.ego.model.params.ScopeName;
 import bio.overture.ego.model.search.SearchFilter;
 import bio.overture.ego.repository.TokenStoreRepository;
@@ -60,7 +63,6 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
@@ -99,17 +101,19 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   /*
    * Dependencies
    */
-  private TokenSigner tokenSigner;
-  private UserService userService;
-  private ApplicationService applicationService;
-  private ApiKeyStoreService apiKeyStoreService;
-  private PolicyService policyService;
+  private final TokenSigner tokenSigner;
+  private final UserService userService;
+  private final ApplicationService applicationService;
+  private final ApiKeyStoreService apiKeyStoreService;
+  private final PolicyService policyService;
   private final UserRepository userRepository;
 
   /** Configuration */
-  private int JWT_DURATION;
+  private final int USER_JWT_DURATION;
 
-  private int API_TOKEN_DURATION;
+  private final int APP_JWT_DURATION;
+
+  private final int API_TOKEN_DURATION;
 
   public TokenService(
       @NonNull TokenSigner tokenSigner,
@@ -119,7 +123,8 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
       @NonNull PolicyService policyService,
       @NonNull TokenStoreRepository tokenStoreRepository,
       @NonNull UserRepository userRepository,
-      @Value("${jwt.durationMs:10800000}") int JWT_DURATION,
+      @Value("${jwt.user.durationMs:10800000}") int USER_JWT_DURATION,
+      @Value("${jwt.app.durationMs:10800000}") int APP_JWT_DURATION,
       @Value("${apitoken.durationDays:365}") int API_TOKEN_DURATION) {
     super(ApiKey.class, tokenStoreRepository);
     this.tokenSigner = tokenSigner;
@@ -128,7 +133,8 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     this.apiKeyStoreService = apiKeyStoreService;
     this.policyService = policyService;
     this.userRepository = userRepository;
-    this.JWT_DURATION = JWT_DURATION;
+    this.USER_JWT_DURATION = USER_JWT_DURATION;
+    this.APP_JWT_DURATION = APP_JWT_DURATION;
     this.API_TOKEN_DURATION = API_TOKEN_DURATION;
   }
 
@@ -173,13 +179,6 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     return new Scope(policy, name.getAccessLevel());
   }
 
-  public Set<Scope> missingScopes(String userName, Set<ScopeName> scopeNames) {
-    val user = userService.getByName(userName);
-    val userScopes = extractScopes(user);
-    val requestedScopes = getScopes(scopeNames);
-    return Scope.missingScopes(userScopes, requestedScopes);
-  }
-
   public String str(Object o) {
     if (o == null) {
       return "null";
@@ -188,11 +187,11 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     }
   }
 
-  public String strList(Collection collection) {
+  public String strList(Collection<?> collection) {
     if (collection == null) {
       return "null";
     }
-    val l = new ArrayList(collection);
+    val l = collection.stream().collect(toUnmodifiableList());
     return l.toString();
   }
 
@@ -269,7 +268,7 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     tokenContext.setScope(scope);
     val tokenClaims = new UserTokenClaims();
     tokenClaims.setIss(ISSUER_NAME);
-    tokenClaims.setValidDuration(JWT_DURATION);
+    tokenClaims.setValidDuration(USER_JWT_DURATION);
     tokenClaims.setContext(tokenContext);
 
     return tokenClaims;
@@ -282,15 +281,19 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     val tokenClaims = new AppTokenClaims();
     tokenContext.setScope(permissionNames);
     tokenClaims.setIss(ISSUER_NAME);
-    tokenClaims.setValidDuration(JWT_DURATION);
+    tokenClaims.setValidDuration(APP_JWT_DURATION);
     tokenClaims.setContext(tokenContext);
     return getSignedToken(tokenClaims);
   }
 
   public boolean isValidToken(String token) {
     Jws<Claims> decodedToken = null;
+    val tokenKey =
+        tokenSigner
+            .getKey()
+            .orElseThrow(() -> new InternalServerException("Internal issue with token signer."));
     try {
-      decodedToken = Jwts.parser().setSigningKey(tokenSigner.getKey().get()).parseClaimsJws(token);
+      decodedToken = Jwts.parser().setSigningKey(tokenKey).parseClaimsJws(token);
     } catch (JwtException e) {
       log.error("JWT token is invalid", e);
     }
@@ -298,9 +301,13 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   public Jws<Claims> validateAndReturn(String token) {
-    Jws<Claims> decodedToken = null;
+    Jws<Claims> decodedToken;
+    val tokenKey =
+        tokenSigner
+            .getKey()
+            .orElseThrow(() -> new InternalServerException("Internal issue with token signer."));
     try {
-      decodedToken = Jwts.parser().setSigningKey(tokenSigner.getKey().get()).parseClaimsJws(token);
+      decodedToken = Jwts.parser().setSigningKey(tokenKey).parseClaimsJws(token);
     } catch (JwtException e) {
       log.error("JWT token is invalid", e);
       throw new ForbiddenException("Authorization is required for this action.");
@@ -394,8 +401,13 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     log.debug(format("apiKey ='%s'", apiKey));
     val contents = BasicAuthToken.decode(authToken);
 
-    val clientId = contents.get().getClientId();
-    val application = applicationService.findByClientId(clientId);
+    val clientId =
+        contents
+            .orElseThrow(() -> new UnauthorizedException("Cannot validate client id"))
+            .getClientId();
+    applicationService
+        .findByClientId(clientId)
+        .orElseThrow(() -> new UnauthorizedException("Not Authorized."));
 
     val aK =
         findByApiKeyString(apiKey).orElseThrow(() -> new InvalidTokenException("ApiKey not found"));
@@ -438,13 +450,11 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   private void revokeApiKeyAsUser(String apiKeyName, User user) {
-    if (userService.isAdmin(user) && userService.isActiveUser(user)) {
-      revoke(apiKeyName);
-    } else {
+    if (!userService.isAdmin(user) || !userService.isActiveUser(user)) {
       // if it's a regular user, check if the api key belongs to the user
       verifyApiKey(apiKeyName, user.getId());
-      revoke(apiKeyName);
     }
+    revoke(apiKeyName);
   }
 
   private void revokeApiKeyAsApplication(String apiKeyName, Application application) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,10 @@ server:
 
 jwt:
   secret: testsecretisalsoasecret
-  durationMs: 10800000 #in milliseconds 10800000 = 3hrs, max = 2147483647
+  user:
+    durationMs: 10800000 #in milliseconds 10800000 = 3hrs, max = 2147483647
+  app:
+    durationMs: 10800000
 
 apitoken:
   durationDays: 365 # in days

--- a/src/test/java/bio/overture/ego/controller/AppJWTTest.java
+++ b/src/test/java/bio/overture/ego/controller/AppJWTTest.java
@@ -315,15 +315,15 @@ public class AppJWTTest extends AbstractControllerTest {
 
     // get app jwt scopes
     val tokenResponse =
-            initStringRequest()
-                    .endpoint("/oauth/token")
-                    .headers(tokenHeaders)
-                    .body(params)
-                    .postAnd()
-                    .assertOk()
-                    .assertHasBody()
-                    .getResponse()
-                    .getBody();
+        initStringRequest()
+            .endpoint("/oauth/token")
+            .headers(tokenHeaders)
+            .body(params)
+            .postAnd()
+            .assertOk()
+            .assertHasBody()
+            .getResponse()
+            .getBody();
 
     val tokenJson = MAPPER.readTree(tokenResponse);
     val accessToken = tokenJson.get("access_token").asText();

--- a/src/test/java/bio/overture/ego/controller/UpdateTokenTest.java
+++ b/src/test/java/bio/overture/ego/controller/UpdateTokenTest.java
@@ -132,7 +132,10 @@ public class UpdateTokenTest extends AbstractControllerTest {
     val firstContext = firstTokenClaims.get("context", LinkedHashMap.class);
     val updatedContext = updatedTokenClaims.get("context", LinkedHashMap.class);
 
-    assertEquals(1, ((Collection) firstContext.get("scope")).size()); // No scopes originally means return default scope
+    assertEquals(
+        1,
+        ((Collection) firstContext.get("scope"))
+            .size()); // No scopes originally means return default scope
     assertTrue(((Collection) firstContext.get("scope")).contains(Scope.defaultScope().toString()));
     assertFalse(
         ((Collection) updatedContext.get("scope")).isEmpty()); // Has scopes in updated token

--- a/src/test/java/selenium/LoadAdminUITest.java
+++ b/src/test/java/selenium/LoadAdminUITest.java
@@ -28,11 +28,13 @@ import java.util.UUID;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
+@Ignore
 public class LoadAdminUITest extends AbstractSeleniumTest {
 
   /** Dependencies */


### PR DESCRIPTION
- User JWT duration is configured via `jwt.user.durationMs`
- App JWT duration is configured via `jwt.app.durationMs`
- Ran google code formatter
- Improved code quality and eliminated many warning from `TokenService.java`
- Removed deprecation annotation as non-deprecated method throws `NotImplemented`

### Did some: 
![image](https://user-images.githubusercontent.com/6350043/100390290-d44d5000-2ffd-11eb-8472-07d41e182a8b.png)
