### PR TITLE
SameSite cookie fix. Allows session cookie to be configured.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
             <artifactId>spring-security-jwt</artifactId>
             <version>1.0.8.RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-core</artifactId>
+        </dependency>
 
         <!-- JDBC -->
         <dependency>

--- a/src/main/java/bio/overture/ego/config/LoginNonceProperties.java
+++ b/src/main/java/bio/overture/ego/config/LoginNonceProperties.java
@@ -30,4 +30,5 @@ public class LoginNonceProperties {
   private String sameSite;
   private boolean secure;
   private int maxAge;
+  private String domainPattern;
 }

--- a/src/main/java/bio/overture/ego/config/LoginNonceProperties.java
+++ b/src/main/java/bio/overture/ego/config/LoginNonceProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package bio.overture.ego.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "login.nonce")
+public class LoginNonceProperties {
+
+  private String name;
+  private String sameSite;
+  private boolean secure;
+  private int maxAge;
+}

--- a/src/main/java/bio/overture/ego/config/SecureServerConfig.java
+++ b/src/main/java/bio/overture/ego/config/SecureServerConfig.java
@@ -16,10 +16,7 @@
 
 package bio.overture.ego.config;
 
-import bio.overture.ego.security.AuthorizationManager;
-import bio.overture.ego.security.JWTAuthorizationFilter;
-import bio.overture.ego.security.OAuth2SsoFilter;
-import bio.overture.ego.security.SecureAuthorizationManager;
+import bio.overture.ego.security.*;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;

--- a/src/main/java/bio/overture/ego/config/SessionConfig.java
+++ b/src/main/java/bio/overture/ego/config/SessionConfig.java
@@ -18,6 +18,7 @@
 package bio.overture.ego.config;
 
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.session.MapSessionRepository;
@@ -30,7 +31,8 @@ public class SessionConfig {
 
   private final LoginNonceProperties properties;
 
-  public SessionConfig(@Autowired LoginNonceProperties properties) {
+  @Autowired
+  public SessionConfig(@NonNull LoginNonceProperties properties) {
     this.properties = properties;
   }
 
@@ -54,11 +56,11 @@ public class SessionConfig {
     serializer.setSameSite(properties.getSameSite());
     serializer.setUseSecureCookie(properties.isSecure());
     serializer.setCookieMaxAge(properties.getMaxAge());
+    serializer.setDomainNamePattern(properties.getDomainPattern());
 
     // These shouldn't be user configurable. ALWAYS make sure its HTTP Only.
     serializer.setUseHttpOnlyCookie(true);
     serializer.setCookiePath("/");
-    serializer.setDomainNamePattern("^.+?\\.(\\w+\\.[a-z]+)$");
     return serializer;
   }
 }

--- a/src/main/java/bio/overture/ego/config/SessionConfig.java
+++ b/src/main/java/bio/overture/ego/config/SessionConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package bio.overture.ego.config;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.session.MapSessionRepository;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+@EnableSpringHttpSession
+public class SessionConfig {
+
+  private final LoginNonceProperties properties;
+
+  public SessionConfig(@Autowired LoginNonceProperties properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Use in memory data store. TODO: Add support for redis and psql data store configurable behind
+   * profiles.
+   *
+   * @return SessionRepository implementation.
+   */
+  @Bean
+  public MapSessionRepository sessionRepository() {
+    return new MapSessionRepository(new ConcurrentHashMap<>());
+  }
+
+  @Bean
+  public CookieSerializer cookieSerializer() {
+    DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+
+    // These can be user configured
+    serializer.setCookieName(properties.getName());
+    serializer.setSameSite(properties.getSameSite());
+    serializer.setUseSecureCookie(properties.isSecure());
+    serializer.setCookieMaxAge(properties.getMaxAge());
+
+    // These shouldn't be useful configurable. ALWAYS make sure its HTTP Only.
+    serializer.setUseHttpOnlyCookie(true);
+    serializer.setCookiePath("/");
+    serializer.setDomainNamePattern("^.+?\\.(\\w+\\.[a-z]+)$");
+    return serializer;
+  }
+}

--- a/src/main/java/bio/overture/ego/config/SessionConfig.java
+++ b/src/main/java/bio/overture/ego/config/SessionConfig.java
@@ -55,7 +55,7 @@ public class SessionConfig {
     serializer.setUseSecureCookie(properties.isSecure());
     serializer.setCookieMaxAge(properties.getMaxAge());
 
-    // These shouldn't be useful configurable. ALWAYS make sure its HTTP Only.
+    // These shouldn't be user configurable. ALWAYS make sure its HTTP Only.
     serializer.setUseHttpOnlyCookie(true);
     serializer.setCookiePath("/");
     serializer.setDomainNamePattern("^.+?\\.(\\w+\\.[a-z]+)$");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,15 @@
 server:
   port: 8081
+  servlet:
+    session:
+      persistent: false
+
+login:
+  nonce:
+    name: LOGIN_NONCE
+    sameSite: none
+    secure: true
+    maxAge: 120
 
 jwt:
   secret: testsecretisalsoasecret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ login:
     sameSite: none
     secure: true
     maxAge: 120
+    domainPattern: ^.+?\.(\w+\.[a-z]+)$
 
 jwt:
   secret: testsecretisalsoasecret


### PR DESCRIPTION
## SameSite cookie setting for cross origin SSO
![image](https://user-images.githubusercontent.com/6350043/102394354-9feb0500-3fa7-11eb-8af2-01beeae5c219.png)

Allows the configuring of the `DefaultCookieSerializer` as part of `spring-session`.  This will allow us to set the `SameSite` attribute to `None` allowing for cross origin logins.

### Configuration 
With sensible defaults:
```yaml
login:
  nonce:
    name: LOGIN_NONCE
    sameSite: none
    secure: true
    maxAge: 120
    domainPattern: ^.+?\.(\w+\.[a-z]+)$
```

A `maxAge` of `-1` will tell the browser to delete the cookie on next close. 

### Usage
Should be transparent to the UI as these are `HttpOnly` cookies.

Example of new cookie in action:
```
Set-Cookie: LOGIN_NONCE=MWMxOTE2MWUtYjU5NS00ZGNkLWE5ZmItMDgzM2U4OTRkNDEy; Max-Age=120; Expires=Wed, 16 Dec 2020 12:55:43 -0500; Path=/; Secure; HttpOnly; SameSite=none
```

### Local Dev
- `SameSite: None` is only allowed when cookie is `Secure`. This means HTTPS only. Otherwise the browser will block the cookie form being set.
- If running Ego on local host, set `SameSite` to `lax` or `strict` and `secure` to `false`. 
