### PR TITLE
Removes the now private spring-repos. Updates grpc.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <mapstruct.version>1.2.0.Final</mapstruct.version>
-        <grpc.version>1.19.0</grpc.version>
+        <grpc.version>1.34.1</grpc.version>
     </properties>
 
     <dependencies>
@@ -368,10 +368,10 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.6.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
                     <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.19.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.34.1:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>
@@ -410,16 +410,8 @@
             <url>https://artifacts.oicr.on.ca/artifactory/dcc-dependencies</url>
         </repository>
         <repository>
-            <id>spring-snapshots</id>
-            <name>Spring Snapshots</name>
-            <url>https://repo.spring.io/libs-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>spring-releases</id>
-            <url>https://repo.spring.io/libs-release</url>
+            <url>https://repo.spring.io/release</url>
         </repository>
         <repository>
             <id>spring-milestones</id>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6350043/102651834-34d23780-413b-11eb-8453-4474c522da44.png)

- Removes the new private spring maven repos
- Updates gRPC dependency as the older version is not in maven central. 