### PR TITLE
🐛 Add email, providerType to allowed search filters

### DIFF
--- a/src/main/java/bio/overture/ego/controller/UserController.java
+++ b/src/main/java/bio/overture/ego/controller/UserController.java
@@ -121,7 +121,8 @@ public class UserController {
       @ApiIgnore @RequestHeader(value = "Authorization", required = true)
           final String authorization,
       @ApiParam(
-              value = "Query string compares to Users Email, First Name, and Last Name fields.",
+              value =
+                  "Query string compares to Users Email, First Name, Last Name, Status and ProviderType fields.",
               required = false)
           @RequestParam(value = "query", required = false)
           String query,

--- a/src/main/java/bio/overture/ego/model/enums/Fields.java
+++ b/src/main/java/bio/overture/ego/model/enums/Fields.java
@@ -25,4 +25,6 @@ public class Fields {
 
   public static final String ID = "id";
   public static final String NAME = "name";
+  public static final String EMAIL = "email";
+  public static final String PROVIDERTYPE = "providerType";
 }

--- a/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
+++ b/src/main/java/bio/overture/ego/repository/queryspecification/UserSpecification.java
@@ -16,15 +16,7 @@
 
 package bio.overture.ego.repository.queryspecification;
 
-import static bio.overture.ego.model.enums.JavaFields.APPLICATION;
-import static bio.overture.ego.model.enums.JavaFields.EMAIL;
-import static bio.overture.ego.model.enums.JavaFields.FIRSTNAME;
-import static bio.overture.ego.model.enums.JavaFields.GROUP;
-import static bio.overture.ego.model.enums.JavaFields.ID;
-import static bio.overture.ego.model.enums.JavaFields.LASTNAME;
-import static bio.overture.ego.model.enums.JavaFields.STATUS;
-import static bio.overture.ego.model.enums.JavaFields.USERAPPLICATIONS;
-import static bio.overture.ego.model.enums.JavaFields.USERGROUPS;
+import static bio.overture.ego.model.enums.JavaFields.*;
 
 import bio.overture.ego.model.entity.Application;
 import bio.overture.ego.model.entity.Group;
@@ -47,7 +39,8 @@ public class UserSpecification extends SpecificationBase<User> {
     return (root, query, builder) -> {
       query.distinct(true);
       return builder.or(
-          getQueryPredicates(builder, root, finalText, EMAIL, FIRSTNAME, LASTNAME, STATUS));
+          getQueryPredicates(
+              builder, root, finalText, EMAIL, FIRSTNAME, LASTNAME, STATUS, PROVIDERTYPE));
     };
   }
 


### PR DESCRIPTION
Adds email and providerType fields to SearchFilters list. This will fix a [request](https://github.com/icgc-argo/Daco2Ego/blob/master/python/ego_client.py#L89) for users in Daco2Ego that wasn't filtering correctly, and allow filtering on `providerType`.
Also adds providerType to User query spec as a nice to have.