### PR TITLE
Remove Auth from API Key Check

### DIFF
--- a/src/main/java/bio/overture/ego/controller/ApiKeyController.java
+++ b/src/main/java/bio/overture/ego/controller/ApiKeyController.java
@@ -95,7 +95,7 @@ public class ApiKeyController {
   public @ResponseBody ApiKeyScopeResponse checkApiKey(
       @RequestHeader(value = "Authorization", required = true) final String authorization,
       @RequestParam(value = "apiKey") final String apiKey) {
-    return tokenService.checkApiKey(authorization, apiKey);
+    return tokenService.checkApiKey(apiKey);
   }
 
   /** DEPRECATED: GET /check_token to be removed in next major release */
@@ -111,7 +111,7 @@ public class ApiKeyController {
       @RequestHeader(value = "Authorization", required = true) final String authorization,
       @RequestParam(value = "token") final String token) {
 
-    return tokenService.checkApiKey(authorization, token);
+    return tokenService.checkApiKey(token);
   }
 
   @RequestMapping(method = GET, value = "/scopes")

--- a/src/main/java/bio/overture/ego/model/dto/ApiKeyScopeResponse.java
+++ b/src/main/java/bio/overture/ego/model/dto/ApiKeyScopeResponse.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 @JsonView(Views.REST.class)
 public class ApiKeyScopeResponse {
   private UUID user_id;
-  private String client_id;
   private Long exp;
   private Set<String> scope;
 }


### PR DESCRIPTION
Removed authorization check from `TokenService.checkApiKey` . Auth checking is done at the request level, it should not be repeated here. See attached ticket for full details.