### PR TITLE
check_api_key should not return HTTP401

### DIFF
--- a/src/main/java/bio/overture/ego/model/exceptions/ClientInvalidTokenException.java
+++ b/src/main/java/bio/overture/ego/model/exceptions/ClientInvalidTokenException.java
@@ -1,0 +1,8 @@
+package bio.overture.ego.model.exceptions;
+
+public class ClientInvalidTokenException extends Exception {
+
+  public ClientInvalidTokenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
+++ b/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
@@ -1,8 +1,7 @@
 package bio.overture.ego.model.exceptions;
 
 import static java.lang.String.format;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 import bio.overture.ego.utils.Joiners;
 import java.util.Date;
@@ -41,6 +40,15 @@ public class ExceptionHandlers {
     val message = buildConstraintViolationMessage(ex);
     log.error(message);
     return new ResponseEntity<Object>(message, new HttpHeaders(), BAD_REQUEST);
+  }
+
+  @ExceptionHandler(ClientInvalidTokenException.class)
+  public ResponseEntity<Object> handleInvalidTokenException(
+      HttpServletRequest req, ClientInvalidTokenException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of("valid", false, "error", message), new HttpHeaders(), OK);
   }
 
   private static String buildConstraintViolationMessage(ConstraintViolationException ex) {

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -399,16 +399,19 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   public ApiKeyScopeResponse checkApiKey(final String apiKey) {
     if (apiKey == null) {
       log.debug("Null apiKey");
-      throw new InvalidTokenException("No apiKey field found in POST request");
+      throw new ClientInvalidTokenException("No apiKey field found in POST request");
     }
 
     log.debug(format("apiKey ='%s'", apiKey));
-
     val aK =
-        findByApiKeyString(apiKey).orElseThrow(() -> new InvalidTokenException("ApiKey not found"));
+        findByApiKeyString(apiKey)
+            .orElseThrow(
+                () -> {
+                  return new ClientInvalidTokenException("ApiKey not found");
+                });
 
     if (aK.isRevoked())
-      throw new InvalidTokenException(
+      throw new ClientInvalidTokenException(
           format("ApiKey \"%s\" has expired or is no longer valid. ", apiKey));
 
     // We want to limit the scopes listed in the apiKey to those scopes that the user

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -399,7 +399,7 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   public ApiKeyScopeResponse checkApiKey(final String apiKey) {
     if (apiKey == null) {
       log.debug("Null apiKey");
-      throw new ClientInvalidTokenException("No apiKey field found in POST request");
+      throw new InvalidRequestException("No apiKey field found in POST request");
     }
 
     log.debug(format("apiKey ='%s'", apiKey));
@@ -407,7 +407,7 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
         findByApiKeyString(apiKey)
             .orElseThrow(
                 () -> {
-                  return new ClientInvalidTokenException("ApiKey not found");
+                  return new InvalidRequestException("ApiKey not found");
                 });
 
     if (aK.isRevoked())


### PR DESCRIPTION
In order to return messages a boolean property "valid".
When the apikey is invalid, return HTTP 200 with response body like:

{
  "valid": false,
  "error": "...message explaining why invalid"
}

 **_Expected Output_** 
<img width="1700" alt="Screenshot 2023-04-03 at 12 34 19 PM" src="https://user-images.githubusercontent.com/121898125/229572296-c68d3b5b-846c-4283-9adf-11aec7334304.png">


