### PR TITLE
Revert "check_api_key should not return HTTP401"

### DIFF
--- a/src/main/java/bio/overture/ego/model/exceptions/ClientInvalidTokenException.java
+++ b/src/main/java/bio/overture/ego/model/exceptions/ClientInvalidTokenException.java
@@ -1,8 +1,0 @@
-package bio.overture.ego.model.exceptions;
-
-public class ClientInvalidTokenException extends Exception {
-
-  public ClientInvalidTokenException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
+++ b/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
@@ -1,7 +1,8 @@
 package bio.overture.ego.model.exceptions;
 
 import static java.lang.String.format;
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import bio.overture.ego.utils.Joiners;
 import java.util.Date;
@@ -40,15 +41,6 @@ public class ExceptionHandlers {
     val message = buildConstraintViolationMessage(ex);
     log.error(message);
     return new ResponseEntity<Object>(message, new HttpHeaders(), BAD_REQUEST);
-  }
-
-  @ExceptionHandler(ClientInvalidTokenException.class)
-  public ResponseEntity<Object> handleInvalidTokenException(
-      HttpServletRequest req, ClientInvalidTokenException ex) {
-    val message = ex.getMessage();
-    log.error(message);
-    return new ResponseEntity<Object>(
-        Map.of("valid", false, "error", message), new HttpHeaders(), OK);
   }
 
   private static String buildConstraintViolationMessage(ConstraintViolationException ex) {

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -399,19 +399,16 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   public ApiKeyScopeResponse checkApiKey(final String apiKey) {
     if (apiKey == null) {
       log.debug("Null apiKey");
-      throw new InvalidRequestException("No apiKey field found in POST request");
+      throw new InvalidTokenException("No apiKey field found in POST request");
     }
 
     log.debug(format("apiKey ='%s'", apiKey));
+
     val aK =
-        findByApiKeyString(apiKey)
-            .orElseThrow(
-                () -> {
-                  return new InvalidRequestException("ApiKey not found");
-                });
+        findByApiKeyString(apiKey).orElseThrow(() -> new InvalidTokenException("ApiKey not found"));
 
     if (aK.isRevoked())
-      throw new ClientInvalidTokenException(
+      throw new InvalidTokenException(
           format("ApiKey \"%s\" has expired or is no longer valid. ", apiKey));
 
     // We want to limit the scopes listed in the apiKey to those scopes that the user


### PR DESCRIPTION
Breaking changes need versioning on the api endpoint. We should also update the success case to have the `valid` boolean flag. More thought needed before we make this change.