### PR TITLE
Changes related to error status 400 and updates to deletion of visa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
+<!--        <dependency>-->
+<!--                 <groupId>com.oauth0</groupId>-->
+<!--                 <artifactId>java-jwt</artifactId>-->
+<!--                 <version>3.8.3</version>-->
+<!--             </dependency>-->
+<!--             <dependency>-->
+<!--                 <groupId>com.oauth0</groupId>-->
+<!--                 <artifactId>jwks-rsa</artifactId>-->
+<!--                 <version>0.21.1</version>-->
+<!--             </dependency>-->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
@@ -403,12 +412,12 @@
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
                     <!-- for Mac OS compatibility -->
-                    <!--<protocArtifact>com.google.protobuf:protoc:3.21.7:exe:osx-x86_64</protocArtifact>-->
-                    <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+                    <protocArtifact>com.google.protobuf:protoc:3.21.7:exe:osx-x86_64</protocArtifact>
+                      <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.54.0:exe:${os.detected.classifier}</pluginArtifact>
                     <!-- for Mac Os compatibility -->
-                    <!--<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>-->
+                   <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -93,16 +93,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-<!--        <dependency>-->
-<!--                 <groupId>com.oauth0</groupId>-->
-<!--                 <artifactId>java-jwt</artifactId>-->
-<!--                 <version>3.8.3</version>-->
-<!--             </dependency>-->
-<!--             <dependency>-->
-<!--                 <groupId>com.oauth0</groupId>-->
-<!--                 <artifactId>jwks-rsa</artifactId>-->
-<!--                 <version>0.21.1</version>-->
-<!--             </dependency>-->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+            <version>0.22.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -412,12 +412,12 @@
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}</protocArtifact>
                     <!-- for Mac OS compatibility -->
-                    <protocArtifact>com.google.protobuf:protoc:3.21.7:exe:osx-x86_64</protocArtifact>
-                      <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
+                    <!--<protocArtifact>com.google.protobuf:protoc:3.21.7:exe:osx-x86_64</protocArtifact>-->
+                    <protoSourceRoot>${basedir}/src/main/proto</protoSourceRoot>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.54.0:exe:${os.detected.classifier}</pluginArtifact>
                     <!-- for Mac Os compatibility -->
-                   <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>
+                    <!--<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>-->
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/bio/overture/ego/controller/VisaController.java
+++ b/src/main/java/bio/overture/ego/controller/VisaController.java
@@ -125,13 +125,14 @@ public class VisaController {
    * @param visaId UUID
    */
   @AdminScoped
-  @RequestMapping(method = DELETE, value = "/{id}")
+  @RequestMapping(method = DELETE, value = "/{type}/{value}")
   @ResponseStatus(value = HttpStatus.OK)
   public void deleteVisa(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization,
-      @PathVariable(value = "id", required = true) UUID id) {
-    visaService.delete(id);
+      @PathVariable(value = "type", required = true) String type,
+      @PathVariable(value = "value", required = true) String value) {
+    visaService.delete(type, value);
   }
 
   /*

--- a/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
+++ b/src/main/java/bio/overture/ego/model/exceptions/ExceptionHandlers.java
@@ -1,8 +1,7 @@
 package bio.overture.ego.model.exceptions;
 
 import static java.lang.String.format;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 import bio.overture.ego.utils.Joiners;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -33,6 +33,21 @@ public class ExceptionHandlers {
             "error", NOT_FOUND.getReasonPhrase()),
         new HttpHeaders(),
         NOT_FOUND);
+  }
+
+  @ExceptionHandler(MissingRequestHeaderException.class)
+  public ResponseEntity<Object> handleMissingRequestHeaderException(
+      HttpServletRequest req, MissingRequestHeaderException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of(
+            "message", ex.getMessage(),
+            "timestamp", new Date(),
+            "path", req.getServletPath(),
+            "error", UNAUTHORIZED.getReasonPhrase()),
+        new HttpHeaders(),
+        UNAUTHORIZED);
   }
 
   @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/bio/overture/ego/service/PassportService.java
+++ b/src/main/java/bio/overture/ego/service/PassportService.java
@@ -4,7 +4,6 @@ import bio.overture.ego.model.dto.Passport;
 import bio.overture.ego.model.dto.PassportVisa;
 import bio.overture.ego.model.entity.Visa;
 import bio.overture.ego.model.entity.VisaPermission;
-import bio.overture.ego.utils.CacheUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
@@ -29,7 +28,7 @@ public class PassportService {
 
   @Autowired private VisaPermissionService visaPermissionService;
 
-  @Autowired private CacheUtil cacheUtil;
+  //  @Autowired private CacheUtil cacheUtil;
 
   @Autowired
   public PassportService(
@@ -90,7 +89,7 @@ public class PassportService {
         .forEach(
             visa -> {
               List<Visa> visaEntities =
-                  visaService.getByTypeAndValueForPassport(
+                  visaService.getByTypeAndValue(
                       visa.getGa4ghVisaV1().getType(), visa.getGa4ghVisaV1().getValue());
               if (visaEntities != null && !visaEntities.isEmpty()) {
                 visaPermissions.addAll(visaPermissionService.getPermissionsForVisa(visaEntities));

--- a/src/main/java/bio/overture/ego/service/PassportService.java
+++ b/src/main/java/bio/overture/ego/service/PassportService.java
@@ -4,8 +4,16 @@ import bio.overture.ego.model.dto.Passport;
 import bio.overture.ego.model.dto.PassportVisa;
 import bio.overture.ego.model.entity.Visa;
 import bio.overture.ego.model.entity.VisaPermission;
+import bio.overture.ego.utils.CacheUtil;
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -28,7 +36,7 @@ public class PassportService {
 
   @Autowired private VisaPermissionService visaPermissionService;
 
-  //  @Autowired private CacheUtil cacheUtil;
+  @Autowired private CacheUtil cacheUtil;
 
   @Autowired
   public PassportService(
@@ -37,11 +45,10 @@ public class PassportService {
     this.visaPermissionService = visaPermissionService;
   }
 
-  public List<VisaPermission> getPermissions(String authToken) throws JsonProcessingException {
+  public List<VisaPermission> getPermissions(String authToken)
+      throws JsonProcessingException, ParseException, JwkException {
     // Validates passport auth token
-    /*if (!isValidPassport(authToken)) {
-      throw new InvalidTokenException("The passport token received from broker is invalid");
-    }*/
+    isValidPassport(authToken);
     // Parses passport JWT token
     Passport parsedPassport = parsePassport(authToken);
     // Fetches visas for parsed passport
@@ -54,12 +61,13 @@ public class PassportService {
   }
 
   // Validates passport token based on public key
-  /*private void isValidPassport(@NonNull String authToken) throws ParseException, JwkException {
+  private void isValidPassport(@NonNull String authToken)
+      throws ParseException, JwkException, JsonProcessingException {
     DecodedJWT jwt = JWT.decode(authToken);
-    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().provider.get(jwt.getKeyId());
+    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().get(jwt.getKeyId());
     Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
     algorithm.verify(jwt);
-  }*/
+  }
 
   // Extracts Visas from parsed passport object
   private List<PassportVisa> getVisas(Passport passport) {
@@ -68,13 +76,12 @@ public class PassportService {
         .forEach(
             visaJwt -> {
               try {
-                // if (visaService.isValidVisa(visaJwt)) {
+                visaService.isValidVisa(visaJwt);
                 PassportVisa visa = visaService.parseVisa(visaJwt);
                 if (visa != null) {
                   visas.add(visa);
                 }
-                // }
-              } catch (JsonProcessingException e) {
+              } catch (JsonProcessingException | JwkException e) {
                 e.printStackTrace();
               }
             });

--- a/src/main/java/bio/overture/ego/service/VisaService.java
+++ b/src/main/java/bio/overture/ego/service/VisaService.java
@@ -9,14 +9,11 @@ import bio.overture.ego.event.token.ApiKeyEventsPublisher;
 import bio.overture.ego.model.dto.PassportVisa;
 import bio.overture.ego.model.dto.VisaRequest;
 import bio.overture.ego.model.entity.Visa;
-import bio.overture.ego.model.exceptions.InvalidTokenException;
 import bio.overture.ego.model.exceptions.NotFoundException;
 import bio.overture.ego.repository.VisaRepository;
 import bio.overture.ego.utils.CacheUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
@@ -81,9 +78,22 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
     }
   }
 
-  public void delete(@NonNull UUID id) {
-    checkExistence(id);
-    super.delete(id);
+  public List<Visa> getByTypeAndValueForPassport(@NonNull String type, @NotNull String value) {
+    val result = visaRepository.getByTypeAndValue(type, value);
+    if (!result.isEmpty()) {
+      return result;
+    }
+    return null;
+  }
+
+  public void delete(@NonNull String type, @NotNull String value) {
+    List<Visa> visas = getByTypeAndValue(type, value);
+    if (visas != null && !visas.isEmpty()) {
+      visas.stream().forEach(visa -> visaRepository.delete(visa));
+    } else {
+      throw new NotFoundException(
+          format("No Visa exists with type '%s' and value '%s'", type, value));
+    }
   }
 
   // Parses Visa JWT token to convert into Visa Object
@@ -99,22 +109,12 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
   }
 
   // Checks if the visa is a valid visa
-  public boolean isValidVisa(@NonNull String authToken) {
-    Claims claims;
-    try {
-      claims =
-          Jwts.parser()
-              .setSigningKey(cacheUtil.getPassportBrokerPublicKey())
-              .parseClaimsJws(authToken)
-              .getBody();
-      if (claims != null) {
-        return true;
-      }
-    } catch (Exception exception) {
-      throw new InvalidTokenException("The visa token received from broker is invalid");
-    }
-    return false;
-  }
+  /*public void isValidVisa(@NonNull String authToken) throws JwkException {
+    DecodedJWT jwt = JWT.decode(authToken);
+    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().provider.get(jwt.getKeyId());
+    Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
+    algorithm.verify(jwt);
+  }*/
 
   public Page<Visa> listVisa(@NonNull Pageable pageable) {
     return visaRepository.findAll(pageable);

--- a/src/main/java/bio/overture/ego/service/VisaService.java
+++ b/src/main/java/bio/overture/ego/service/VisaService.java
@@ -11,9 +11,16 @@ import bio.overture.ego.model.dto.VisaRequest;
 import bio.overture.ego.model.entity.Visa;
 import bio.overture.ego.model.exceptions.NotFoundException;
 import bio.overture.ego.repository.VisaRepository;
+import bio.overture.ego.utils.CacheUtil;
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.constraints.NotNull;
+import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +49,7 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
   /** Dependencies */
   @Autowired private VisaRepository visaRepository;
 
-  //  @Autowired private CacheUtil cacheUtil;
+  @Autowired private CacheUtil cacheUtil;
 
   private final ApiKeyEventsPublisher apiKeyEventsPublisher;
 
@@ -99,12 +106,12 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
   }
 
   // Checks if the visa is a valid visa
-  /*public void isValidVisa(@NonNull String authToken) throws JwkException {
+  public void isValidVisa(@NonNull String authToken) throws JwkException, JsonProcessingException {
     DecodedJWT jwt = JWT.decode(authToken);
-    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().provider.get(jwt.getKeyId());
+    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().get(jwt.getKeyId());
     Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
     algorithm.verify(jwt);
-  }*/
+  }
 
   public Page<Visa> listVisa(@NonNull Pageable pageable) {
     return visaRepository.findAll(pageable);

--- a/src/main/java/bio/overture/ego/utils/CacheUtil.java
+++ b/src/main/java/bio/overture/ego/utils/CacheUtil.java
@@ -1,48 +1,50 @@
-package bio.overture.ego.utils;
-
-import static bio.overture.ego.model.exceptions.InternalServerException.buildInternalServerException;
-import static org.springframework.http.HttpMethod.GET;
-
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.HttpStatusCodeException;
-import org.springframework.web.client.RestTemplate;
-
-@Slf4j
-@Component
-public class CacheUtil {
-
-  @Value("${broker.publicKey.url}")
-  private String brokerPublicKeyUrl;
-
-  private RestTemplate restTemplate;
-
-  @Cacheable("getPassportBrokerPublicKey")
-  public String getPassportBrokerPublicKey() {
-    ResponseEntity<String> response;
-    try {
-      response = restTemplate.exchange(brokerPublicKeyUrl, GET, null, String.class);
-    } catch (HttpStatusCodeException err) {
-      log.error(
-          "Invalid {} response from passport broker service: {}",
-          err.getStatusCode().value(),
-          err.getMessage());
-      throw buildInternalServerException(
-          "Invalid %s response from passport broker service.", err.getStatusCode().value());
-    }
-    return response.getBody();
-  }
-
-  @CacheEvict(value = "evictAll", allEntries = true)
-  public void evictAllCaches() {}
-
-  @Scheduled(fixedRate = 6000)
-  public void evictAllCachesEveryDay() {
-    evictAllCaches();
-  }
-}
+// package bio.overture.ego.utils;
+//
+// import static
+// bio.overture.ego.model.exceptions.InternalServerException.buildInternalServerException;
+// import static org.springframework.http.HttpMethod.GET;
+//
+// import com.nimbusds.jose.jwk.JWKSet;
+// import lombok.extern.slf4j.Slf4j;
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.cache.annotation.CacheEvict;
+// import org.springframework.cache.annotation.Cacheable;
+// import org.springframework.http.ResponseEntity;
+// import org.springframework.scheduling.annotation.Scheduled;
+// import org.springframework.stereotype.Component;
+// import org.springframework.web.client.HttpStatusCodeException;
+// import org.springframework.web.client.RestTemplate;
+//
+// @Slf4j
+// @Component
+// public class CacheUtil {
+//
+//  @Value("${broker.publicKey.url}")
+//  private String brokerPublicKeyUrl;
+//
+//  private RestTemplate restTemplate;
+//
+//  @Cacheable("getPassportBrokerPublicKey")
+//  public JWKSet getPassportBrokerPublicKey() {
+//    ResponseEntity<JWKSet> response;
+//    try {
+//      response = restTemplate.exchange(brokerPublicKeyUrl, GET, null, JWKSet.class);
+//    } catch (HttpStatusCodeException err) {
+//      log.error(
+//          "Invalid {} response from passport broker service: {}",
+//          err.getStatusCode().value(),
+//          err.getMessage());
+//      throw buildInternalServerException(
+//          "Invalid %s response from passport broker service.", err.getStatusCode().value());
+//    }
+//    return response.getBody();
+//  }
+//
+//  @CacheEvict(value = "evictAll", allEntries = true)
+//  public void evictAllCaches() {}
+//
+//  @Scheduled(fixedRate = 6000)
+//  public void evictAllCachesEveryDay() {
+//    evictAllCaches();
+//  }
+// }

--- a/src/main/java/bio/overture/ego/utils/CacheUtil.java
+++ b/src/main/java/bio/overture/ego/utils/CacheUtil.java
@@ -1,50 +1,65 @@
-// package bio.overture.ego.utils;
-//
-// import static
-// bio.overture.ego.model.exceptions.InternalServerException.buildInternalServerException;
-// import static org.springframework.http.HttpMethod.GET;
-//
-// import com.nimbusds.jose.jwk.JWKSet;
-// import lombok.extern.slf4j.Slf4j;
-// import org.springframework.beans.factory.annotation.Value;
-// import org.springframework.cache.annotation.CacheEvict;
-// import org.springframework.cache.annotation.Cacheable;
-// import org.springframework.http.ResponseEntity;
-// import org.springframework.scheduling.annotation.Scheduled;
-// import org.springframework.stereotype.Component;
-// import org.springframework.web.client.HttpStatusCodeException;
-// import org.springframework.web.client.RestTemplate;
-//
-// @Slf4j
-// @Component
-// public class CacheUtil {
-//
-//  @Value("${broker.publicKey.url}")
-//  private String brokerPublicKeyUrl;
-//
-//  private RestTemplate restTemplate;
-//
-//  @Cacheable("getPassportBrokerPublicKey")
-//  public JWKSet getPassportBrokerPublicKey() {
-//    ResponseEntity<JWKSet> response;
-//    try {
-//      response = restTemplate.exchange(brokerPublicKeyUrl, GET, null, JWKSet.class);
-//    } catch (HttpStatusCodeException err) {
-//      log.error(
-//          "Invalid {} response from passport broker service: {}",
-//          err.getStatusCode().value(),
-//          err.getMessage());
-//      throw buildInternalServerException(
-//          "Invalid %s response from passport broker service.", err.getStatusCode().value());
-//    }
-//    return response.getBody();
-//  }
-//
-//  @CacheEvict(value = "evictAll", allEntries = true)
-//  public void evictAllCaches() {}
-//
-//  @Scheduled(fixedRate = 6000)
-//  public void evictAllCachesEveryDay() {
-//    evictAllCaches();
-//  }
-// }
+package bio.overture.ego.utils;
+
+import static bio.overture.ego.model.exceptions.InternalServerException.buildInternalServerException;
+import static org.springframework.http.HttpMethod.GET;
+
+import com.auth0.jwk.Jwk;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+public class CacheUtil {
+
+  @Value("${broker.publicKey.url}")
+  private String brokerPublicKeyUrl;
+
+  private RestTemplate restTemplate;
+
+  @Cacheable("getPassportBrokerPublicKey")
+  public Map<String, Jwk> getPassportBrokerPublicKey() throws JsonProcessingException {
+    ResponseEntity<Map<String, List>> response;
+    Map<String, Jwk> jwkMap = new HashMap();
+    try {
+      restTemplate = new RestTemplate();
+      response =
+          restTemplate.exchange(
+              brokerPublicKeyUrl,
+              GET,
+              null,
+              new ParameterizedTypeReference<Map<String, List>>() {});
+    } catch (HttpStatusCodeException err) {
+      log.error(
+          "Invalid {} response from passport broker config: {}",
+          err.getStatusCode().value(),
+          err.getMessage());
+      throw buildInternalServerException(
+          "Invalid %s response from passport broker config.", err.getStatusCode().value());
+    }
+    for (Object obj : response.getBody().get("keys")) {
+      Jwk jwkObject = Jwk.fromValues((Map<String, Object>) obj);
+      jwkMap.put(jwkObject.getId(), jwkObject);
+    }
+    return jwkMap;
+  }
+
+  @CacheEvict(value = "evictAll", allEntries = true)
+  public void evictAllCaches() {}
+
+  @Scheduled(fixedRate = 6000)
+  public void evictAllCachesEveryDay() {
+    evictAllCaches();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -186,7 +186,7 @@ token:
 
 broker:
   publicKey:
-    url: http://localhost:8082/token/public_key
+    url: https://login.elixir-czech.org/oidc/jwk
 
 # Default values available for creation of entities
 default:


### PR DESCRIPTION
As mentioned in the earlier ticker #708 ,The issues related to API's returning HTTP 400 error status has now been fixed. With the recent changes, if any user does not authenticated with valid jwt the error code returns back as HTTP 401 (Unauthorized) with a error status {
  "error": "Unauthorized",
  "message": "Required request header 'Authorization' for method parameter type String is not present",
  "timestamp": "2023-06-01T16:00:02.624+0000",
  "path": "/visa"
}

Steps to reproduce: 

1. Go to 'http://localhost:8081/swagger-ui/index.html#/Visa/deleteVisa'
2. Do not provide any api key in "Authorize" tab.
3. Test any api within ego
4. Response returned is HTTP 400 Bad Request

**Below is the ss, displaying the error status**
<img width="1482" alt="Screenshot 2023-06-01 at 1 20 09 PM" src="https://github.com/overture-stack/ego/assets/121898125/3cdb25cc-41e2-4bea-b798-7c28c373aa93">


The second change is regarding the updates to deletion of visa. Earlier, there was an option to delete the Visa with using VisaId as a parameter. Now, as we are no longer using the VisaId to fetch or update. Therefore, "type" and "value" can be used to delete the Visa now.
