### PR TITLE
multiple passport brokers & passport refresh token

### DIFF
--- a/src/main/java/bio/overture/ego/config/OAuth2AccessTokenResponseConverterWithDefaults.java
+++ b/src/main/java/bio/overture/ego/config/OAuth2AccessTokenResponseConverterWithDefaults.java
@@ -20,7 +20,6 @@ public class OAuth2AccessTokenResponseConverterWithDefaults
               OAuth2ParameterNames.ACCESS_TOKEN,
               OAuth2ParameterNames.TOKEN_TYPE,
               OAuth2ParameterNames.EXPIRES_IN,
-              OAuth2ParameterNames.REFRESH_TOKEN,
               OAuth2ParameterNames.SCOPE)
           .collect(Collectors.toSet());
 

--- a/src/main/java/bio/overture/ego/controller/AuthController.java
+++ b/src/main/java/bio/overture/ego/controller/AuthController.java
@@ -18,6 +18,7 @@ package bio.overture.ego.controller;
 
 import static bio.overture.ego.model.enums.JavaFields.REFRESH_ID;
 import static bio.overture.ego.utils.SwaggerConstants.AUTH_CONTROLLER;
+import static bio.overture.ego.utils.TypeUtils.isValidUUID;
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 import static org.springframework.web.bind.annotation.RequestMethod.*;
@@ -27,9 +28,7 @@ import bio.overture.ego.model.exceptions.InvalidScopeException;
 import bio.overture.ego.model.exceptions.InvalidTokenException;
 import bio.overture.ego.provider.google.GoogleTokenService;
 import bio.overture.ego.security.CustomOAuth2User;
-import bio.overture.ego.service.PassportService;
-import bio.overture.ego.service.RefreshContextService;
-import bio.overture.ego.service.TokenService;
+import bio.overture.ego.service.*;
 import bio.overture.ego.token.IDToken;
 import bio.overture.ego.token.signer.TokenSigner;
 import bio.overture.ego.utils.Tokens;
@@ -50,6 +49,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
 @RestController
@@ -65,6 +65,7 @@ public class AuthController {
   private final GoogleTokenService googleTokenService;
   private final TokenSigner tokenSigner;
   private final RefreshContextService refreshContextService;
+  private final UserService userService;
   private final String GA4GH_PASSPORT_SCOPE = "ga4gh_passport_v1";
 
   @Autowired
@@ -73,12 +74,14 @@ public class AuthController {
       @NonNull PassportService passportService,
       @NonNull GoogleTokenService googleTokenService,
       @NonNull TokenSigner tokenSigner,
-      @NonNull RefreshContextService refreshContextService) {
+      @NonNull RefreshContextService refreshContextService,
+      @NonNull UserService userService) {
     this.tokenService = tokenService;
     this.passportService = passportService;
     this.googleTokenService = googleTokenService;
     this.tokenSigner = tokenSigner;
     this.refreshContextService = refreshContextService;
+    this.userService = userService;
   }
 
   @RequestMapping(method = GET, value = "/google/token")
@@ -126,42 +129,54 @@ public class AuthController {
       throw new RuntimeException("no user");
     }
 
-    val user = (CustomOAuth2User) authentication.getPrincipal();
+    val oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
+    val passportJwtToken =
+        (oAuth2User.getClaim(GA4GH_PASSPORT_SCOPE) != null)
+            ? passportService.getPassportToken(
+                authentication.getAuthorizedClientRegistrationId(), oAuth2User.getAccessToken())
+            : null;
 
-    val passportJwtToken = (user.getClaim(GA4GH_PASSPORT_SCOPE) != null) ?
-        passportService.getPassportToken(
-            authentication.getAuthorizedClientRegistrationId(),
-            user.getAccessToken()) :
-        null;
+    Optional<ProviderType> providerType =
+        ProviderType.findIfExist(authentication.getAuthorizedClientRegistrationId());
 
-    Optional<ProviderType> providerType = ProviderType
-        .findIfExist(authentication.getAuthorizedClientRegistrationId());
-
-    if(user.getClaim(GA4GH_PASSPORT_SCOPE) != null && providerType.isEmpty()){
+    if (oAuth2User.getClaim(GA4GH_PASSPORT_SCOPE) != null && providerType.isEmpty()) {
       providerType = Optional.of(ProviderType.PASSPORT);
     }
 
-    String token =
-        tokenService.generateUserToken(
-            IDToken.builder()
-                .providerSubjectId(user.getSubjectId())
-                .email(user.getEmail())
-                .familyName(user.getFamilyName())
-                .givenName(user.getGivenName())
-                .providerType(providerType.get())
-                .providerIssuerUri(user.getIssuer().toString())
-                .build(),
-            passportJwtToken,
-            authentication.getAuthorizedClientRegistrationId());
+    val idToken =
+        IDToken.builder()
+            .providerSubjectId(oAuth2User.getSubjectId())
+            .email(oAuth2User.getEmail())
+            .familyName(oAuth2User.getFamilyName())
+            .givenName(oAuth2User.getGivenName())
+            .providerType(providerType.get())
+            .providerIssuerUri(oAuth2User.getIssuer().toString())
+            .build();
 
-    val outgoingRefreshContext = refreshContextService.createInitialRefreshContext(token);
-    val cookie =
-        refreshContextService.createRefreshCookie(outgoingRefreshContext.getRefreshToken());
-    response.addCookie(cookie);
+    val egoToken =
+        tokenService.generateUserToken(
+            idToken, passportJwtToken, authentication.getAuthorizedClientRegistrationId());
+
+    if (oAuth2User.getClaim(GA4GH_PASSPORT_SCOPE) != null && oAuth2User.getRefreshToken() != null) {
+      // create a cookie with passport refresh token
+      val user = userService.getUserByToken(idToken);
+      val outgoingRefreshContext =
+          refreshContextService.createPassportRefreshToken(user, oAuth2User.getRefreshToken());
+      val cookie =
+          refreshContextService.createPassportRefreshCookie(
+              outgoingRefreshContext, oAuth2User.getRefreshToken());
+      response.addCookie(cookie);
+    } else {
+      // create a cookie with refreshId
+      val outgoingRefreshContext = refreshContextService.createInitialRefreshContext(egoToken);
+      val cookie =
+          refreshContextService.createRefreshCookie(outgoingRefreshContext.getRefreshToken());
+      response.addCookie(cookie);
+    }
 
     SecurityContextHolder.getContext().setAuthentication(null);
-    return new ResponseEntity<>(token, OK);
+    return new ResponseEntity<>(egoToken, OK);
   }
 
   @RequestMapping(
@@ -200,15 +215,41 @@ public class AuthController {
       return new ResponseEntity<>("Please login", UNAUTHORIZED);
     }
     val currentToken = Tokens.removeTokenPrefix(authorization, TOKEN_PREFIX);
-    // TODO: [anncatton] validate jwt before proceeding to service call.
 
-    val outboundUserToken =
-        refreshContextService.validateAndReturnNewUserToken(refreshId, currentToken);
-    val newRefreshToken = tokenService.getTokenUserInfo(outboundUserToken).getRefreshToken();
-    val newCookie = refreshContextService.createRefreshCookie(newRefreshToken);
-    response.addCookie(newCookie);
+    try {
+      if (isValidUUID(refreshId)) {
+        val outboundUserToken =
+            refreshContextService.validateAndReturnNewUserToken(refreshId, currentToken);
+        val newRefreshToken = tokenService.getTokenUserInfo(outboundUserToken).getRefreshToken();
+        val newCookie = refreshContextService.createRefreshCookie(newRefreshToken);
+        response.addCookie(newCookie);
 
-    return new ResponseEntity<>(outboundUserToken, OK);
+        return new ResponseEntity<>(outboundUserToken, OK);
+      } else {
+
+        val user = tokenService.getTokenUserInfo(currentToken);
+
+        val clientRegistration =
+            passportService.getPassportClientRegistrations().get(user.getProviderIssuerUri());
+
+        val passportResponse =
+            passportService.refreshToken(clientRegistration.getRegistrationId(), refreshId);
+
+        val egoToken = tokenService.generatePassportEgoToken(user, passportResponse.getAccess_token(), clientRegistration.getRegistrationId());
+
+        val outgoingRefreshContext =
+            refreshContextService.createPassportRefreshToken(
+                user, passportResponse.getRefresh_token());
+        val newCookie =
+            refreshContextService.createPassportRefreshCookie(
+                outgoingRefreshContext, passportResponse.getRefresh_token());
+        response.addCookie(newCookie);
+
+        return new ResponseEntity<>(egoToken, OK);
+      }
+    }catch (HttpClientErrorException e){
+      return new ResponseEntity<>(e.getResponseBodyAsString(), e.getStatusCode());
+    }
   }
 
   @ExceptionHandler({InvalidTokenException.class})

--- a/src/main/java/bio/overture/ego/model/dto/CreateUserRequest.java
+++ b/src/main/java/bio/overture/ego/model/dto/CreateUserRequest.java
@@ -47,4 +47,6 @@ public class CreateUserRequest {
   @NotNull ProviderType providerType;
 
   @NotNull String providerSubjectId;
+
+  private String providerIssuerUri;
 }

--- a/src/main/java/bio/overture/ego/model/dto/PassportRefreshToken.java
+++ b/src/main/java/bio/overture/ego/model/dto/PassportRefreshToken.java
@@ -1,0 +1,21 @@
+package bio.overture.ego.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.val;
+
+import java.util.Calendar;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PassportRefreshToken {
+  private String iss;
+  private String aud;
+  private Long exp; // in seconds
+  private String jti;
+
+  public Long getSecondsUntilExpiry() {
+    val seconds = this.exp - Calendar.getInstance().getTime().getTime() / 1000L;
+    return seconds > 0 ? seconds : 0;
+  }
+}

--- a/src/main/java/bio/overture/ego/model/dto/PassportRefreshTokenResponse.java
+++ b/src/main/java/bio/overture/ego/model/dto/PassportRefreshTokenResponse.java
@@ -1,0 +1,15 @@
+package bio.overture.ego.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PassportRefreshTokenResponse {
+  private String access_token;
+  private String token_type;
+  private String refresh_token;
+  private Long expires_in;
+  private String scope;
+  private String id_token;
+}

--- a/src/main/java/bio/overture/ego/model/entity/User.java
+++ b/src/main/java/bio/overture/ego/model/entity/User.java
@@ -148,6 +148,10 @@ public class User implements PolicyOwner, Identifiable<UUID> {
   @Column(name = SqlFields.PROVIDERSUBJECTID, nullable = false)
   private String providerSubjectId;
 
+  @JsonView({Views.JWTAccessToken.class, Views.REST.class})
+  @Column(name = SqlFields.PROVIDERISSUERURI)
+  private String providerIssuerUri;
+
   @JsonIgnore
   @OneToMany(
       mappedBy = JavaFields.OWNER,

--- a/src/main/java/bio/overture/ego/model/enums/ProviderType.java
+++ b/src/main/java/bio/overture/ego/model/enums/ProviderType.java
@@ -8,6 +8,8 @@ import bio.overture.ego.model.exceptions.ForbiddenException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 public enum ProviderType {
   GOOGLE,
@@ -51,6 +53,12 @@ public enum ProviderType {
                     format(
                         "The provider type '%s' cannot be resolved. Must be one of: [%s]",
                         providerType, COMMA.join(values()))));
+  }
+
+  public static Optional<ProviderType> findIfExist(@NonNull String providerType) {
+    return stream(values())
+        .filter(x -> x.toString().equalsIgnoreCase(providerType))
+        .findFirst();
   }
 
   @Override

--- a/src/main/java/bio/overture/ego/model/enums/SqlFields.java
+++ b/src/main/java/bio/overture/ego/model/enums/SqlFields.java
@@ -36,6 +36,7 @@ public class SqlFields {
   public static final String USER_ID = "user_id";
   public static final String PROVIDERTYPE = "providertype";
   public static final String PROVIDERSUBJECTID = "providersubjectid";
+  public static final String PROVIDERISSUERURI = "providerissueruri";
   public static final String INITIALIZED = "initialized";
   public static final String ERRORREDIRECTURI = "errorredirecturi";
   public static final String SOURCE = "source";

--- a/src/main/java/bio/overture/ego/security/CustomOAuth2User.java
+++ b/src/main/java/bio/overture/ego/security/CustomOAuth2User.java
@@ -24,6 +24,7 @@ public class CustomOAuth2User implements OidcUser {
   private String email;
   private OAuth2User oauth2User;
   private String accessToken;
+  private String refreshToken;
 
   @Override
   public Map<String, Object> getAttributes() {
@@ -49,6 +50,8 @@ public class CustomOAuth2User implements OidcUser {
   }
 
   public String getAccessToken() { return this.accessToken; }
+
+  public String getRefreshToken() {return this.refreshToken; }
 
   public String getSubjectId() {
     return oauth2User.getAttributes().containsKey(IdTokenClaimNames.SUB)

--- a/src/main/java/bio/overture/ego/security/CustomOidc2UserInfoService.java
+++ b/src/main/java/bio/overture/ego/security/CustomOidc2UserInfoService.java
@@ -36,9 +36,9 @@ public class CustomOidc2UserInfoService extends OidcUserService {
     OidcUser oidcUser = super.loadUser(oAuth2UserRequest);
     try {
       String provider = oAuth2UserRequest.getClientRegistration().getRegistrationId();
-      val idName = ProviderType.getIdAccessor(ProviderType.resolveProviderType(provider));
       if (provider.equalsIgnoreCase(ProviderType.ORCID.toString())) {
         val info = getOrcidUserInfo(oidcUser, oAuth2UserRequest);
+        val idName = ProviderType.getIdAccessor(ProviderType.resolveProviderType(provider));
         return CustomOAuth2User.builder()
             .oauth2User(new DefaultOAuth2User(oidcUser.getAuthorities(), info, idName))
             .subjectId(info.get(idName).toString())

--- a/src/main/java/bio/overture/ego/security/CustomOidc2UserInfoService.java
+++ b/src/main/java/bio/overture/ego/security/CustomOidc2UserInfoService.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -47,6 +48,8 @@ public class CustomOidc2UserInfoService extends OidcUserService {
             .givenName(info.getOrDefault(GIVEN_NAME, "").toString())
             .build();
       }
+
+      val refreshToken = getRefreshToken(oAuth2UserRequest);
       return CustomOAuth2User.builder()
           .oauth2User(oidcUser)
           .subjectId(oidcUser.getSubject())
@@ -54,6 +57,7 @@ public class CustomOidc2UserInfoService extends OidcUserService {
           .familyName(oidcUser.getFamilyName())
           .givenName(oidcUser.getGivenName())
           .accessToken(oAuth2UserRequest.getAccessToken().getTokenValue())
+          .refreshToken(refreshToken)
           .build();
     } catch (AuthenticationException ex) {
       throw ex;
@@ -86,5 +90,12 @@ public class CustomOidc2UserInfoService extends OidcUserService {
               return z.execute(x, y);
             });
     return restTemplate;
+  }
+
+  private String getRefreshToken(OAuth2UserRequest oAuth2UserRequest) {
+    val refreshToken =
+        (String)
+            oAuth2UserRequest.getAdditionalParameters().get(OAuth2ParameterNames.REFRESH_TOKEN);
+    return refreshToken;
   }
 }

--- a/src/main/java/bio/overture/ego/service/PassportService.java
+++ b/src/main/java/bio/overture/ego/service/PassportService.java
@@ -1,9 +1,9 @@
 package bio.overture.ego.service;
 
-import bio.overture.ego.model.dto.Passport;
-import bio.overture.ego.model.dto.PassportToken;
-import bio.overture.ego.model.dto.PassportVisa;
-import bio.overture.ego.model.dto.Scope;
+import static bio.overture.ego.utils.CollectionUtils.mapToSet;
+
+import bio.overture.ego.model.dto.*;
+import bio.overture.ego.model.entity.User;
 import bio.overture.ego.model.entity.Visa;
 import bio.overture.ego.model.entity.VisaPermission;
 import bio.overture.ego.utils.CacheUtil;
@@ -16,12 +16,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.NonNull;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.codec.binary.Base64;
@@ -31,14 +29,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import static bio.overture.ego.utils.CollectionUtils.mapToSet;
 
 @Slf4j
 @Service
@@ -55,10 +52,14 @@ public class PassportService {
 
   @Autowired private ClientRegistrationRepository clientRegistrationRepository;
 
-  private final String REQUESTED_TOKEN_TYPE = "urn:ga4gh:params:oauth:token-type:passport";
-  private final String SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
-  private final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange";
+  @Autowired private InMemoryClientRegistrationRepository inMemoryClientRegistrationRepository;
 
+  private final String TOKEN_TYPE_PASSPORT = "urn:ga4gh:params:oauth:token-type:passport";
+  private final String TOKEN_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token";
+  private final String GRANT_TYPE_TOKEN_EXCHANGE =
+      "urn:ietf:params:oauth:grant-type:token-exchange";
+  private final String REFRESH_TOKEN = "refresh_token";
+  private final String GA4GH_PASSPORT_SCOPE = "ga4gh_passport_v1";
 
   @Autowired
   public PassportService(
@@ -127,25 +128,34 @@ public class PassportService {
     return visaPermissions;
   }
 
-  public Set<Scope> extractScopes(@NonNull String passportJwtToken, @NonNull String providerType) throws ParseException, JwkException, JsonProcessingException {
-      val resolvedPermissions = getPermissions(passportJwtToken, providerType);
-      val output = mapToSet(resolvedPermissions, AbstractPermissionService::buildScope);
-      if (output.isEmpty()) {
-        output.add(Scope.defaultScope());
-      }
-      return output;
+  public Set<Scope> extractScopes(@NonNull String passportJwtToken, @NonNull String providerType)
+      throws ParseException, JwkException, JsonProcessingException {
+    val resolvedPermissions = getPermissions(passportJwtToken, providerType);
+    val output = mapToSet(resolvedPermissions, AbstractPermissionService::buildScope);
+    if (output.isEmpty()) {
+      output.add(Scope.defaultScope());
+    }
+    return output;
   }
 
   // Parse Passport token to extract the passport body
-  public Passport parsePassport(@NonNull String passportJwtToken) throws JsonProcessingException {
-    String[] split_string = passportJwtToken.split("\\.");
-    String base64EncodedHeader = split_string[0];
-    String base64EncodedBody = split_string[1];
-    String base64EncodedSignature = split_string[2];
-    Base64 base64Url = new Base64(true);
-    String header = new String(base64Url.decode(base64EncodedHeader));
-    String body = new String(base64Url.decode(base64EncodedBody));
+  @SneakyThrows
+  private Passport parsePassport(@NonNull String passportJwtToken) {
+    val body = decodeJwtBody(passportJwtToken);
     return new ObjectMapper().readValue(body, Passport.class);
+  }
+
+  @SneakyThrows
+  private PassportRefreshToken parseRefreshToken(@NonNull String jwtRefreshToken) {
+    val body = decodeJwtBody(jwtRefreshToken);
+    return new ObjectMapper().readValue(body, PassportRefreshToken.class);
+  }
+
+  private String decodeJwtBody(@NonNull String jwtToken){
+    val split_string = jwtToken.split("\\.");
+    val base64EncodedBody = split_string[1];
+    val base64Url = new Base64(true);
+    return new String(base64Url.decode(base64EncodedBody));
   }
 
   // Removes duplicates from the VisaPermissons List
@@ -161,21 +171,46 @@ public class PassportService {
 
     val clientRegistration = clientRegistrationRepository.findByRegistrationId(providerId);
 
-    val uri = UriComponentsBuilder
-        .fromUriString(clientRegistration.getProviderDetails().getTokenUri())
-        .queryParams(passportTokenParams(accessToken))
-        .toUriString();
+    val uri =
+        UriComponentsBuilder.fromUriString(clientRegistration.getProviderDetails().getTokenUri())
+            .queryParams(passportTokenParams(accessToken))
+            .toUriString();
 
-    val passportToken = getTemplate(clientRegistration)
-                .exchange(uri,
-                    HttpMethod.POST,
-                    null,
-                    PassportToken.class)
-                .getBody();
+    val passportToken =
+        getTemplate(clientRegistration)
+            .exchange(uri, HttpMethod.POST, null, PassportToken.class)
+            .getBody();
 
-    return (passportToken != null) ?
-      passportToken.getAccess_token() :
-        null;
+    return (passportToken != null) ? passportToken.getAccess_token() : null;
+  }
+
+
+  public PassportRefreshTokenResponse refreshToken(String providerId, String refreshJwtToken) {
+    if (refreshJwtToken == null || refreshJwtToken.isEmpty()) return null;
+
+    val clientRegistration = clientRegistrationRepository.findByRegistrationId(providerId);
+
+    val uri =
+        UriComponentsBuilder.fromUriString(clientRegistration.getProviderDetails().getTokenUri())
+            .queryParams(refreshPassportTokenParams(clientRegistration, refreshJwtToken))
+            .toUriString();
+
+    return getTemplate(clientRegistration)
+        .exchange(uri, HttpMethod.POST, null, PassportRefreshTokenResponse.class)
+        .getBody();
+  }
+
+  public Map<String, ClientRegistration> getPassportClientRegistrations() {
+    Map<String, ClientRegistration> passportProviderDetails = new HashMap<>();
+
+    inMemoryClientRegistrationRepository.forEach(
+        clientRegistration -> {
+          if (clientRegistration.getScopes().contains(GA4GH_PASSPORT_SCOPE)) {
+            passportProviderDetails.put(
+                clientRegistration.getProviderDetails().getIssuerUri(), clientRegistration);
+          }
+        });
+    return passportProviderDetails;
   }
 
   private RestTemplate getTemplate(ClientRegistration clientRegistration) {
@@ -187,7 +222,10 @@ public class PassportService {
               x.getHeaders()
                   .set(
                       HttpHeaders.AUTHORIZATION,
-                      "Basic " + getBasicAuthHeader(clientRegistration.getClientId(), clientRegistration.getClientSecret()));
+                      "Basic "
+                          + getBasicAuthHeader(
+                              clientRegistration.getClientId(),
+                              clientRegistration.getClientSecret()));
               return z.execute(x, y);
             });
     return restTemplate;
@@ -198,12 +236,31 @@ public class PassportService {
     return new String(Base64.encodeBase64(credentials.getBytes()));
   }
 
-  private MultiValueMap<String, String> passportTokenParams(String accessToken){
+  private MultiValueMap<String, String> passportTokenParams(String accessToken) {
     MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-    params.add("requested_token_type", REQUESTED_TOKEN_TYPE);
+    params.add("requested_token_type", TOKEN_TYPE_PASSPORT);
     params.add("subject_token", accessToken);
-    params.add("subject_token_type", SUBJECT_TOKEN_TYPE);
-    params.add("grant_type", GRANT_TYPE);
+    params.add("subject_token_type", TOKEN_TYPE_ACCESS_TOKEN);
+    params.add("grant_type", GRANT_TYPE_TOKEN_EXCHANGE);
     return params;
+  }
+
+  private MultiValueMap<String, String> refreshPassportTokenParams(
+      ClientRegistration clientRegistration, String refreshJwtToken) {
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("client_id", clientRegistration.getClientId());
+    params.add("client_secret", clientRegistration.getClientSecret());
+    params.add("refresh_token", refreshJwtToken);
+    params.add("grant_type", REFRESH_TOKEN);
+    return params;
+  }
+
+  @SneakyThrows
+  public PassportRefreshToken getRefreshTokenClaims(String jwtToken, User user) {
+    isValidPassport(
+        jwtToken,
+        this.getPassportClientRegistrations().get(user.getProviderIssuerUri()).getRegistrationId());
+
+    return parseRefreshToken(jwtToken);
   }
 }

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -141,12 +141,12 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   public String generateUserToken(IDToken idToken) {
-    return generateUserToken(idToken, null);
+    return generateUserToken(idToken, null, null);
   }
 
-  public String generateUserToken(IDToken idToken, String passportJwtToken) {
+  public String generateUserToken(IDToken idToken, String passportJwtToken, String providerType) {
     val user = userService.getUserByToken(idToken);
-    return generateUserToken(user, passportJwtToken);
+    return generateUserToken(user, passportJwtToken, providerType);
   }
 
   public String updateUserToken(String accessToken) {
@@ -175,12 +175,12 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   @SneakyThrows
-  public String generateUserToken(User u, String passportJwtToken) {
+  public String generateUserToken(User u, String passportJwtToken, String providerType) {
 
     Set<String> scopes = extractExplicitScopes(u);
 
-    if (passportJwtToken != null){
-      Set<String> scopesFromVisas = extractExplicitScopes(passportJwtToken);
+    if (passportJwtToken != null && providerType != null){
+      Set<String> scopesFromVisas = extractExplicitScopes(passportJwtToken, providerType);
       scopes = mergeScopes(scopes, scopesFromVisas);
     }
 
@@ -601,8 +601,8 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   @SneakyThrows
-  private Set<String> extractExplicitScopes(String passportJwtToken){
-    return mapToSet(explicitScopes(passportService.extractScopes(passportJwtToken)), Scope::toString);
+  private Set<String> extractExplicitScopes(String passportJwtToken, String providerType){
+    return mapToSet(explicitScopes(passportService.extractScopes(passportJwtToken, providerType)), Scope::toString);
   }
 
   private Set<String> mergeScopes(Set<String> scopeSet, Set<String> scopeSetAdditional){

--- a/src/main/java/bio/overture/ego/service/TokenService.java
+++ b/src/main/java/bio/overture/ego/service/TokenService.java
@@ -60,14 +60,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -146,7 +139,30 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
 
   public String generateUserToken(IDToken idToken, String passportJwtToken, String providerType) {
     val user = userService.getUserByToken(idToken);
+    if (passportJwtToken == null || providerType == null) {
+      return generateUserToken(user);
+    }
+
     return generateUserToken(user, passportJwtToken, providerType);
+  }
+
+  public String generatePassportEgoToken(User user, String passportAccessToken, String registrationId){
+    val passportJwtToken =
+        passportService.getPassportToken(
+            registrationId, passportAccessToken);
+
+    val idToken =
+        IDToken.builder()
+            .providerSubjectId(user.getProviderSubjectId())
+            .email(user.getEmail())
+            .familyName(user.getLastName())
+            .givenName(user.getFirstName())
+            .providerType(user.getProviderType())
+            .providerIssuerUri(user.getProviderIssuerUri())
+            .build();
+
+    return generateUserToken(
+        idToken, passportJwtToken, registrationId);
   }
 
   public String updateUserToken(String accessToken) {
@@ -179,22 +195,12 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
 
     Set<String> scopes = extractExplicitScopes(u);
 
-    if (passportJwtToken != null && providerType != null){
+    if (passportJwtToken != null && providerType != null) {
       Set<String> scopesFromVisas = extractExplicitScopes(passportJwtToken, providerType);
       scopes = mergeScopes(scopes, scopesFromVisas);
     }
 
     return generateUserToken(u, scopes);
-  }
-
-  @SneakyThrows
-  public String generateUserToken(UUID userId) {
-    val user = userService.findById(userId);
-    if (user.isEmpty()) {
-      throw new NotFoundException("user not found");
-    }
-    val u = user.get();
-    return generateUserToken(u, extractExplicitScopes(u));
   }
 
   public Set<Scope> getScopes(Set<ScopeName> scopeNames) {
@@ -286,7 +292,7 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
     return UUID.randomUUID().toString();
   }
 
-  public String generateUserToken(@NonNull User u, @NonNull Set<String> scope) {
+  private String generateUserToken(@NonNull User u, @NonNull Set<String> scope) {
     val tokenClaims = generateUserTokenClaims(u, scope);
     return getSignedToken(tokenClaims);
   }
@@ -601,13 +607,15 @@ public class TokenService extends AbstractNamedService<ApiKey, UUID> {
   }
 
   @SneakyThrows
-  private Set<String> extractExplicitScopes(String passportJwtToken, String providerType){
-    return mapToSet(explicitScopes(passportService.extractScopes(passportJwtToken, providerType)), Scope::toString);
+  private Set<String> extractExplicitScopes(String passportJwtToken, String providerType) {
+    return mapToSet(
+        explicitScopes(passportService.extractScopes(passportJwtToken, providerType)),
+        Scope::toString);
   }
 
-  private Set<String> mergeScopes(Set<String> scopeSet, Set<String> scopeSetAdditional){
+  private Set<String> mergeScopes(Set<String> scopeSet, Set<String> scopeSetAdditional) {
     scopeSet.addAll(scopeSetAdditional);
-    if(scopeSet.size()>1 && scopeSet.contains(Scope.defaultScope().toString())){
+    if (scopeSet.size() > 1 && scopeSet.contains(Scope.defaultScope().toString())) {
       scopeSet.remove(Scope.defaultScope().toString());
     }
     return scopeSet;

--- a/src/main/java/bio/overture/ego/service/UserService.java
+++ b/src/main/java/bio/overture/ego/service/UserService.java
@@ -175,6 +175,7 @@ public class UserService extends AbstractBaseService<User, UUID> {
             .type(userDefaultsConfig.getDefaultUserType())
             .providerType(idToken.getProviderType())
             .providerSubjectId(idToken.getProviderSubjectId())
+            .providerIssuerUri(idToken.getProviderIssuerUri())
             .build());
   }
 

--- a/src/main/java/bio/overture/ego/service/VisaService.java
+++ b/src/main/java/bio/overture/ego/service/VisaService.java
@@ -105,7 +105,8 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
   }
 
   // Checks if the visa is a valid visa
-  public void isValidVisa(@NonNull String authToken, @NonNull String providerType) throws JwkException, JsonProcessingException {
+  public void isValidVisa(@NonNull String authToken, @NonNull String providerType)
+      throws JwkException, JsonProcessingException {
     DecodedJWT jwt = JWT.decode(authToken);
     Jwk jwk = cacheUtil.getPassportBrokerPublicKey(providerType).get(jwt.getKeyId());
     Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
@@ -130,9 +131,7 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
       }
     } else {
       throw new NotFoundException(
-          format(
-              "No Visa exists with type '%s' and value '%s'",
-              type, value));
+          format("No Visa exists with type '%s' and value '%s'", type, value));
     }
     return updatedVisas;
   }

--- a/src/main/java/bio/overture/ego/service/VisaService.java
+++ b/src/main/java/bio/overture/ego/service/VisaService.java
@@ -105,9 +105,9 @@ public class VisaService extends AbstractNamedService<Visa, UUID> {
   }
 
   // Checks if the visa is a valid visa
-  public void isValidVisa(@NonNull String authToken) throws JwkException, JsonProcessingException {
+  public void isValidVisa(@NonNull String authToken, @NonNull String providerType) throws JwkException, JsonProcessingException {
     DecodedJWT jwt = JWT.decode(authToken);
-    Jwk jwk = cacheUtil.getPassportBrokerPublicKey().get(jwt.getKeyId());
+    Jwk jwk = cacheUtil.getPassportBrokerPublicKey(providerType).get(jwt.getKeyId());
     Algorithm algorithm = Algorithm.RSA256((RSAPublicKey) jwk.getPublicKey(), null);
     algorithm.verify(jwt);
   }

--- a/src/main/java/bio/overture/ego/token/IDToken.java
+++ b/src/main/java/bio/overture/ego/token/IDToken.java
@@ -43,4 +43,6 @@ public class IDToken {
   @JsonProperty("provider_subject_id")
   @NonNull
   String providerSubjectId;
+
+  private String providerIssuerUri;
 }

--- a/src/main/java/bio/overture/ego/utils/TypeUtils.java
+++ b/src/main/java/bio/overture/ego/utils/TypeUtils.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import lombok.val;
 
 public class TypeUtils {
@@ -39,5 +40,15 @@ public class TypeUtils {
     mapper.configure(JsonGenerator.Feature.IGNORE_UNKNOWN, true);
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper.convertValue(fromObject, tClass);
+  }
+
+  private static final Pattern UUID_REGEX_PATTERN =
+      Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$");
+
+  public static boolean isValidUUID(String str) {
+    if (str == null) {
+      return false;
+    }
+    return UUID_REGEX_PATTERN.matcher(str).matches();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ spring:
               - openid
               - email
               - profile
+              - offline_access
               - ga4gh_passport_v1
 
           github:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,8 @@ spring:
               - openid
               - email
               - profile
+
+          # Passport brokers must have ga4gh_passport_v1 scope
           passport:
             clientId: ego-client
             clientSecret:
@@ -197,9 +199,6 @@ token:
   private-key: MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDSU6oy48sJW6xzqzOSU1dAvUUeFKQSBHsCf7wGWUGpOxEczhtFiiyx4YUJtg+fyvwWxa4wO3GnQLBPIxBHY8JsnvjQN2lsTUoLqMB9nGpwF617uA/S2igm1u+cDpfi82kbi6SG1Sg30PM047R6oxTRGDLLkeMRF1gRaTBM0HfSL0j6ccU5KPgwYsFLE2We6jeR56iYJGC2KYLH4v8rcc2jRAdMbUntHMtUByF9BPSW7elQnyQH5Qzr/o0b59XLKwnJFn2Bp2yviC8cdyTDyhQGna0e+oESQR1j6u3Ux/mOmm3slRXscA8sH+pHmOEAtjYVf/ww36U8uZv+ctBCJyFVAgMBAAECggEBALrEeJqAFUfWFCkSmdUSFKT0bW/svFUTjXgGnZy1ncz9GpENpMH3lQDQVibteKpYwcom+Cr0XlQ66VUcudPrDjcOY7vhuMfnSh1YWLYyM4IeRHtcUxDVkFoM+vEFNHLf2zIOqqbgmboW3iDVIurT7iRO7KxAe/YtWJL9aVqMtBn7Lu7S7OvAU4ji5iLIBxjl82JYA+9lu/aQ6YGaoZuSO7bcU8Sivi+DKAahqN9XMKiB1XpC+PpaS/aec2S7xIlTdzoDGxEALRGlMe+xBEeQTBVJHBWrRIDPoHLTREeRC/9Pp+1Y4Dz8hd5Bi0n8/5r/q0liD+0vtmjsdU4E2QrktYECgYEA73qWvhCYHPMREAFtwz1mpp9ZhDCW6SF+njG7fBKcjz8OLcy15LXiTGc268ewtQqTMjPQlm1n2C6hGccGAIlMibQJo3KZHlTs125FUzDpTVgdlei6vU7M+gmfRSZed00J6jC04/qMR1tnV3HME3np7eRTKTA6Ts+zBwEvkbCetSkCgYEA4NY5iSBO1ybouIecDdD15uI2ItLPCBNMzu7IiK7IygIzuf+SyKyjhtFSR4vEi0gScOM7UMlwCMOVU10e4nMDknIWCDG9iFvmIEkGHGxgRrN5hX1Wrq74wF212lvvagH1IVWSHa8cVpMe+UwKu5Q1h4yzuYt6Q9wPQ7Qtn5emBE0CgYB2syispMUA9GnsqQii0Xhj9nAEWaEzhOqhtrzbTs5TIkoA4Yr3BkBY5oAOdjhcRBWZuJ0XMrtaKCKqCEAtW+CYEKkGXvMOWcHbNkkeZwv8zkQ73dNRqhFnjgVn3RDNyV20uteueK23YNLkQP+KV89fnuCpdcIw9joiqq/NYuIHoQKBgB5WaZ8KH/lCA8babYEjv/pubZWXUl4plISbja17wBYZ4/bl+F1hhhMr7Wk//743dF2NG7TT6W0VTvHXr9IoaMP65uQmKgfbNpsGn294ZClGEFClz+t0KpZyTpZvL0fjibr8u+GLfkxkP5qt2wjif7KRlrKjklTTva+KAVn2cW1FAoGBAMkX9ekIwhx/7uY6ndxKl8ZMDerjr6MhV0b08hHp3RxHbYVbcpN0UKspoYvZVgHwP18xlDij8yWRE2fapwgi4m82ZmYlg0qqJmyqIU9vBB3Jow903h1KPQrkmQEZxJ/4H8yrbgVf2HT+WUfjTFgaDZRl01bI3YkydCw91/Ub9HU6
   public-key: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0lOqMuPLCVusc6szklNXQL1FHhSkEgR7An+8BllBqTsRHM4bRYosseGFCbYPn8r8FsWuMDtxp0CwTyMQR2PCbJ740DdpbE1KC6jAfZxqcBete7gP0tooJtbvnA6X4vNpG4ukhtUoN9DzNOO0eqMU0Rgyy5HjERdYEWkwTNB30i9I+nHFOSj4MGLBSxNlnuo3keeomCRgtimCx+L/K3HNo0QHTG1J7RzLVAchfQT0lu3pUJ8kB+UM6/6NG+fVyysJyRZ9gadsr4gvHHckw8oUBp2tHvqBEkEdY+rt1Mf5jppt7JUV7HAPLB/qR5jhALY2FX/8MN+lPLmb/nLQQichVQIDAQAB
 
-broker:
-  publicKey:
-    url: https://login.elixir-czech.org/oidc/jwk
 
 # Default values available for creation of entities
 default:

--- a/src/main/resources/flyway/sql/V1_25__add_provider_issuer_uri.sql
+++ b/src/main/resources/flyway/sql/V1_25__add_provider_issuer_uri.sql
@@ -1,0 +1,1 @@
+ALTER TABLE egouser ADD COLUMN providerissueruri VARCHAR(255);


### PR DESCRIPTION
changes:
- Identify a Passport broker by scope "ga4gh_passport_v1"
- get client credentials and JWK uri from clientRegistrationRepository
- add column providerissueruri for passport users
- Fix bug #723 